### PR TITLE
Evaluate state changes locally

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,12 +23,12 @@
         </div>
         <div>
           <select id="selectedTile">
-            <option value="0" selected>Empty</option>
-            <option value="1">Wall</option>
-            <option value="2">Collectable</option>
-            <option value="3">Rock</option>
-            <option value="4">Dirt</option>
-            <option value="5">Player</option>
+            <option value="Empty" selected>Empty</option>
+            <option value="Wall">Wall</option>
+            <option value="Collectable">Collectable</option>
+            <option value="Rock">Rock</option>
+            <option value="Dirt">Dirt</option>
+            <option value="Player">Player</option>
           </select>
         </div>
         <div>
@@ -42,8 +42,8 @@
     </div>
   </body>
   <script type="module">
-    import { Board, base64EncodeBoard, base64DecodeBoard, tileNames } from "./src/board.js";
-    import { State, applyGravityToFallingRocks, movePlayer, updateFallingRocks } from "./src/state.js";
+    import { Board, base64EncodeBoard, base64DecodeBoard } from "./src/board.js";
+    import { State, applyTileUpdates, movePlayer } from "./src/state.js";
 
     const tickMs = 250;
     const tileSize = 20;
@@ -52,10 +52,29 @@
     function drawTile(context, tile, x, y, width, height) {
       context.save();
 
+      let tileIndex;
+      if (tile.type === "Empty") {
+        tileIndex = 0;
+      } else if (tile.type === "Wall") {
+        tileIndex = 1;
+      } else if (tile.type === "Collectable") {
+        tileIndex = 2;
+      } else if (tile.type === "Rock") {
+        tileIndex = 3;
+      } else if (tile.type === "Dirt") {
+        tileIndex = 4;
+      } else if (tile.type === "Player" && tile.isAlive) {
+        tileIndex = 5;
+      } else if (tile.type === "Player" && !tile.isAlive) {
+        tileIndex = 6;
+      } else {
+        throw new Error("Unknown tile");
+      }
+
       context.drawImage(
         tiles,
         0,
-        tiles.naturalWidth * tile,
+        tiles.naturalWidth * tileIndex,
         tiles.naturalWidth,
         tiles.naturalWidth,
         x,
@@ -67,26 +86,49 @@
       context.restore();
     }
 
-    function renderBoard(canvas, board, originalBoard) {
+    function renderBoard(canvas, board, updatedPoints) {
       const context = canvas.getContext("2d");
 
       const tileWidth = canvas.width / board.width;
       const tileHeight = canvas.height / board.height;
 
-      const areBoardsCompatible =
-        board.width === originalBoard?.width &&
-        board.height === originalBoard?.height;
-
-      board.tiles.forEach((tile, index) => {
-        if (areBoardsCompatible && tile === originalBoard.tiles[index]) {
-          return;
+      if (updatedPoints === undefined) {
+        updatedPoints = [];
+        for (let x = 0; x < board.width; ++x) {
+          for (let y = 0; y < board.height; ++y) {
+            updatedPoints.push([x, y]);
+          }
         }
+      }
 
-        const tileX = index % board.width;
-        const tileY = Math.floor(index / board.width);
+      const pointsWithTiles = updatedPoints.map(([x, y]) => ({
+        x,
+        y,
+        tile: board.getTile(x, y),
+      }));
 
-        drawTile(context, tile, tileX * tileWidth, tileY * tileHeight, tileWidth, tileHeight);
+      pointsWithTiles.forEach(({x, y, tile}) => {
+        drawTile(context, tile, x * tileWidth, y * tileHeight, tileWidth, tileHeight);
       });
+    }
+
+    function createTile(type) {
+      switch (type) {
+        case "Empty":
+        case "Wall":
+        case "Collectable":
+        case "Dirt":
+          return { type };
+
+        case "Player":
+          return { type, isAlive: true };
+
+        case "Rock":
+          return { type, fallingDirection: "None" };
+
+        default:
+          throw new Error("Unknown tile");
+      }
     }
 
     function updateTile(mouseEvent) {
@@ -96,14 +138,13 @@
       const tileX = Math.floor(mouseEvent.offsetX / tileWidth);
       const tileY = Math.floor(mouseEvent.offsetY / tileHeight);
 
-      const tile = parseInt(selectedTileInput.selectedOptions[0].value);
+      const tile = selectedTileInput.selectedOptions[0].value;
       const originalTile = board.getTile(tileX, tileY);
 
-      if (tile !== originalTile) {
-        const originalBoard = board.clone();
-        board.setTile(tileX, tileY, tile);
+      if (tile !== originalTile.type) {
+        board.setTile(tileX, tileY, createTile(tile));
         generatedBoardOutput.value = base64EncodeBoard(board);
-        renderBoard(boardElement, board, originalBoard);
+        renderBoard(boardElement, board, [[tileX, tileY]]);
       }
     }
 
@@ -137,17 +178,15 @@
     }
 
     function renderGameState(state) {
-      const remaining = state.board.tiles.filter(tile => tile === tileNames.COLLECTABLE).length;
-      const isAlive = state.board.tiles.some(tile => tile === tileNames.PLAYER);
+      const remaining = state.board.tiles.filter(tile => tile.type === "Collectable").length;
+      const isAlive = state.board.tiles.some(tile => tile.type === "Player" && tile.isAlive);
       gameStateElement.textContent = `${state.collected} collected, ${remaining} remaining, ${isAlive ? "alive" : "dead"}`;
     }
 
     function handleInput(keyboardEvent) {
-      if (state.fallingRocks.length > 0) {
+      if (state.updatedTiles.length > 0) {
         return;
       }
-
-      const originalBoard = state.board.clone();
 
       let handled = true;
       switch (keyboardEvent.key) {
@@ -180,9 +219,8 @@
       }
 
       if (handled) {
-        updateFallingRocks(state);
-        applyGravityToFallingRocks(state);
-        renderBoard(boardElement, state.board, originalBoard);
+        const updatedPoints = applyTileUpdates(state);
+        renderBoard(boardElement, state.board, updatedPoints);
         renderGameState(state);
         keyboardEvent.preventDefault(); // Prevent other browser behaviors
       }
@@ -233,7 +271,7 @@
       playButton.blur(); // Returns focus to the document
 
       state = new State(board.clone());
-      updateFallingRocks(state);
+      state.updateEntireBoard();
       renderGameState(state);
 
       document.addEventListener("keydown", handleInput);
@@ -245,10 +283,9 @@
 
       timerId = setInterval(
         () => {
-          if (state.fallingRocks.length > 0) {
-            const originalBoard = state.board.clone();
-            applyGravityToFallingRocks(state);
-            renderBoard(boardElement, state.board, originalBoard);
+          if (state.updatedTiles.length > 0) {
+            const updatedPoints = applyTileUpdates(state);
+            renderBoard(boardElement, state.board, updatedPoints);
             renderGameState(state);
           }
         },

--- a/src/state.js
+++ b/src/state.js
@@ -1,16 +1,8 @@
-import { tileNames } from "./board.js";
+import { Board } from "./board.js";
 
 /**
- * @typedef {import("./board.js").Board} Board
- * @typedef {(
- *  "Up" |
- *  "Left" |
- *  "Down" |
- *  "Right" |
- *  "DownLeft" |
- *  "DownRight" |
- *  "None"
- * )} Direction
+ * @typedef {import("./board.js").Direction} Direction
+ * @typedef {import("./board.js").Tile} Tile
  * @typedef {[number, number]} Point
  */
 
@@ -25,58 +17,49 @@ export class State {
     /** @type {number} */
     this.collected = 0;
 
-    /** @type {[number, number, Direction][][]} */
-    this.fallingRocks = [];
+    /** @type {Point[]} */
+    this.updatedTiles = [];
   }
 
   /**
    * @param {number} x
    * @param {number} y
-   * @returns {Direction}
-  */
-  getFallingDirection(x, y) {
-    const tile = this.board.getTile(x, y);
-    if (tile !== tileNames.ROCK) {
-      return "None";
-    }
-
-    for (const line of this.fallingRocks) {
-      const fallingRock = line.find(
-        ([tileX, tileY]) => tileX === x && tileY === y
-      );
-
-      if (fallingRock) {
-        return fallingRock[2];
-      }
-    }
-
-    return "None";
-  }
-
-  /**
-   * @param {number} x
-   * @param {number} y
-   * @param {Direction} direction
+   * @param {Tile} tile
    */
-  setFallingRock(x, y, direction) {
-    /** @type [number, number, Direction] */
-    const fallingRock = [x, y, direction];
-    for (let index = 0; index < this.fallingRocks.length; ++index) {
-      const line = this.fallingRocks[index];
-      if (line.length > 0) {
-        if (line[0][1] === y) {
-          line.push(fallingRock);
-          return;
-        } else if (line[0][1] < y) {
-          const newLine = [fallingRock];
-          this.fallingRocks.splice(index, 0, newLine);
-          return;
-        }
+  setTile(x, y, tile) {
+    this.board.setTile(x, y, tile);
+    this.addUpdatedTile(x, y);
+    this.addUpdatedTile(x - 1, y);
+    this.addUpdatedTile(x - 1, y - 1);
+    this.addUpdatedTile(x - 1, y + 1);
+    this.addUpdatedTile(x + 1, y);
+    this.addUpdatedTile(x + 1, y - 1);
+    this.addUpdatedTile(x + 1, y + 1);
+    this.addUpdatedTile(x, y - 1);
+    this.addUpdatedTile(x, y + 1);
+  }
+
+  /**
+   * @param {number} x
+   * @param {number} y
+   */
+  addUpdatedTile(x, y) {
+    if (
+      this.board.isInBounds(x, y) &&
+      this.updatedTiles.every(point => point[0] !== x || point[1] !== y)
+    ) {
+      this.updatedTiles.push([x, y]);
+    }
+  }
+
+  updateEntireBoard() {
+    this.updatedTiles = [];
+
+    for (let y = this.board.height - 1; y >= 0; --y) {
+      for (let x = this.board.width - 1; x >= 0; --x) {
+        this.updatedTiles.push([x, y]);
       }
     }
-
-    const newLine = [fallingRock];
-    this.fallingRocks.push(newLine);
   }
 }
 
@@ -132,25 +115,13 @@ function nextCoordinateInDirection(x, y, direction) {
  * @param {Direction} direction
  */
 function canMoveToLocation(board, x, y, direction) {
-  if (!board.isInBounds(x, y)) {
-    return false;
-  }
-
   const tile = board.getTile(x, y);
-  if (
-    tile === tileNames.WALL ||
-    tile === tileNames.DEAD_PLAYER ||
-    tile === tileNames.PLAYER
-  ) {
+  if (tile.type === "Wall" || tile.type === "Player") {
     return false;
-  } else if (tile === tileNames.ROCK) {
+  } else if (tile.type === "Rock") {
     const [nextX, nextY] = nextCoordinateInDirection(x, y, direction);
-    if (!board.isInBounds(nextX, nextY)) {
-      return false;
-    }
-
     const nextTile = board.getTile(nextX, nextY);
-    if (nextTile !== tileNames.EMPTY && nextTile !== tileNames.DIRT) {
+    if (nextTile.type !== "Empty" && nextTile.type !== "Dirt") {
       return false;
     }
   }
@@ -163,12 +134,14 @@ function canMoveToLocation(board, x, y, direction) {
  *
  * @param {State} state
  * @param {Direction} direction
+ * @returns {Point[]} the points that were updated
  */
 export function movePlayer(state, direction) {
   const playerPositions = state.board.tiles.
     map((tile, index) => ({ tile, index })).
-    filter(({ tile }) => tile === tileNames.PLAYER).
-    map(({ index }) => ({
+    filter(({ tile }) => tile.type === "Player" && tile.isAlive).
+    map(({ tile, index }) => ({
+      tile,
       x: index % state.board.width,
       y: Math.floor(index / state.board.width),
     }));
@@ -185,217 +158,235 @@ export function movePlayer(state, direction) {
     return b.x - a.x;
   });
 
-  for (const { x, y } of playerPositions) {
+  /** @type {Point[]} */
+  const updatedPoints = [];
+  for (const { tile: playerTile, x, y } of playerPositions) {
     const [newX, newY] = nextCoordinateInDirection(x, y, direction);
 
     if (canMoveToLocation(state.board, newX, newY, direction)) {
       const tile = state.board.getTile(newX, newY);
-      if (tile === tileNames.COLLECTABLE) {
+      if (tile.type === "Collectable") {
         ++state.collected;
       }
 
-      state.board.setTile(x, y, tileNames.EMPTY);
-      state.board.setTile(newX, newY, tileNames.PLAYER);
+      state.setTile(x, y, Board.EMPTY_TILE);
+      state.setTile(newX, newY, playerTile);
 
-      if (tile === tileNames.ROCK) {
+      updatedPoints.push([x, y]);
+      updatedPoints.push([newX, newY]);
+
+      if (tile.type === "Rock") {
         const [nextX, nextY] = nextCoordinateInDirection(
           newX,
           newY,
           direction
         );
-        state.board.setTile(nextX, nextY, tileNames.ROCK);
+        state.setTile(nextX, nextY, tile);
+        updatedPoints.push([nextX, nextY]);
       }
     }
   }
+
+  return updatedPoints;
 }
 
 /**
- * @param {State} state
- * @param {number} x
- * @param {number} y
+ * Sorts the points from bottom right to top left
+ *
+ * @param {Point[]} points
  */
-function isTileFallingRock(state, x, y) {
-  return state.getFallingDirection(x, y) !== "None";
+function reverseSortPoints(points) {
+  return [...points].sort((p1, p2) => {
+    if (p1[1] > p2[1]) {
+      return -1;
+    } else if (p1[1] < p2[1]) {
+      return 1;
+    } else if (p1[0] > p2[0]) {
+      return -1;
+    } else if (p1[0] < p2[0]) {
+      return 1;
+    }
+
+    return 0;
+  });
 }
 
 /**
- * Whether a rock can fall straight down
+ * Gets the falling direction for a rock at a given point
  *
  * @param {State} state
  * @param {number} x
  * @param {number} y
+ * @returns {Direction}
  */
-function canFallDown(state, x, y) {
-  if (!state.board.isInBounds(x, y + 1)) {
-    return false;
-  }
-
+function getFallingDirection(state, x, y) {
   const tileBelow = state.board.getTile(x, y + 1);
-  return tileBelow === tileNames.EMPTY ||
-    tileBelow === tileNames.PLAYER ||
-    isTileFallingRock(state, x, y + 1);
+  if (
+    tileBelow.type === "Empty" ||
+    tileBelow.type === "Player" ||
+    (tileBelow.type === "Rock" && tileBelow.fallingDirection !== "None")
+  ) {
+    return "Down";
+  } else if (tileBelow.type === "Rock") {
+    const tileLeft = state.board.getTile(x - 1, y);
+    const tileBelowLeft = state.board.getTile(x - 1, y + 1);
+    if (
+      (
+        tileLeft.type === "Empty" ||
+        (tileLeft.type === "Rock" && tileLeft.fallingDirection !== "None")
+      ) &&
+      (
+        tileBelowLeft.type === "Empty" ||
+        tileBelowLeft.type === "Player" ||
+        (
+          tileBelowLeft.type === "Rock" &&
+          tileBelowLeft.fallingDirection !== "None"
+        )
+      )
+    ) {
+      return "DownLeft";
+    }
+
+    const tileRight = state.board.getTile(x + 1, y);
+    const tileBelowRight = state.board.getTile(x + 1, y + 1);
+    if (
+      (
+        tileRight.type === "Empty" ||
+        (tileRight.type === "Rock" && tileRight.fallingDirection !== "None")
+      ) &&
+      (
+        tileBelowRight.type === "Empty" ||
+        tileBelowRight.type === "Player" ||
+        (
+          tileBelowRight.type === "Rock" &&
+          tileBelowRight.fallingDirection !== "None"
+        )
+      )
+    ) {
+      return "DownRight";
+    }
+  }
+
+  return "None";
 }
 
 /**
- * Whether a rock can fall to the left
+ * Updates a single tile based on the region around it
  *
  * @param {State} state
  * @param {number} x
  * @param {number} y
+ * @returns {Point[]} the points that were updated
  */
-function canFallLeft(state, x, y) {
-  if (!state.board.isInBounds(x - 1, y + 1) || canFallDown(state, x, y)) {
-    return false;
-  }
+function updateTile(state, x, y) {
+  const tile = state.board.getTile(x, y);
+  const tileAbove = state.board.getTile(x, y - 1);
+  const tileAboveRight = state.board.getTile(x + 1, y - 1);
+  const tileAboveLeft = state.board.getTile(x - 1, y - 1);
+  if (tile.type === "Player") {
+    if (
+      (tileAbove.type === "Rock" && tileAbove.fallingDirection === "Down") ||
+      (
+        tileAboveLeft.type === "Rock" &&
+        tileAboveLeft.fallingDirection === "DownRight"
+      ) ||
+      (
+        tileAboveRight.type === "Rock" &&
+        tileAboveRight.fallingDirection === "DownLeft"
+      )
+    ) {
+      tile.isAlive = false;
+      return [[x, y]];
+    }
+  } else if (tile.type === "Rock") {
+    const tileBelow = state.board.getTile(x, y + 1);
+    const tileBelowRight = state.board.getTile(x + 1, y + 1);
+    const tileBelowLeft = state.board.getTile(x - 1, y + 1);
+    if (tileBelow.type === "Empty") {
+      state.setTile(
+        x,
+        y + 1,
+        {
+          type: "Rock",
+          fallingDirection: getFallingDirection(state, x, y + 1),
+        }
+      );
+      state.setTile(x, y, Board.EMPTY_TILE);
 
-  const tileBelow = state.board.getTile(x, y + 1);
-  const tileLeft = state.board.getTile(x - 1, y);
-  const tileBelowLeft = state.board.getTile(x - 1, y + 1);
-  return tileBelow === tileNames.ROCK &&
-    (tileLeft === tileNames.EMPTY || isTileFallingRock(state, x - 1, y)) &&
-    (
-      tileBelowLeft === tileNames.EMPTY ||
-      isTileFallingRock(state, x - 1, y + 1) ||
-      tileBelowLeft === tileNames.PLAYER
-    );
-}
-
-/**
- * Whether a rock can fall to the right
- *
- * @param {State} state
- * @param {number} x
- * @param {number} y
- */
-function canFallRight(state, x, y) {
-  if (!state.board.isInBounds(x + 1, y + 1) || canFallDown(state, x, y)) {
-    return false;
-  }
-
-  const tileBelow = state.board.getTile(x, y + 1);
-  const tileRight = state.board.getTile(x + 1, y);
-  const tileBelowRight = state.board.getTile(x + 1, y + 1);
-  return tileBelow === tileNames.ROCK &&
-    (tileRight === tileNames.EMPTY || isTileFallingRock(state, x + 1, y)) &&
-    (
-      tileBelowRight === tileNames.EMPTY ||
-      isTileFallingRock(state, x + 1, y + 1) ||
-      tileBelowRight === tileNames.PLAYER
-    );
-}
-
-/**
- * Updates all rocks that could start falling to do so
- *
- * @param {State} state
- */
-export function updateFallingRocks(state) {
-  if (state.fallingRocks.length > 0) {
-    return;
-  }
-
-  // Skip the last row since rocks on the last row can't fall
-  for (let y = state.board.height - 2; y >= 0; --y) {
-    /** @type [number, number, Direction][] */
-    const line = [];
-    for (let x = state.board.width - 1; x >= 0; --x) {
-      const tile = state.board.getTile(x, y);
-      const tileBelow = state.board.getTile(x, y + 1);
-      if (
-        tile === tileNames.ROCK &&
-        tileBelow !== tileNames.PLAYER &&
-        canFallDown(state, x, y) &&
-        state.getFallingDirection(x, y) === "None"
+      return [
+        [x, y + 1],
+        [x, y],
+      ];
+    } else if (
+      tile.fallingDirection !== "None" &&
+      tileBelow.type === "Rock" &&
+      tileBelow.fallingDirection === "None"
+    ) {
+      const tileLeft = state.board.getTile(x - 1, y);
+      const tileRight = state.board.getTile(x + 1, y);
+      const fallingDirection = getFallingDirection(state, x, y);
+      if (fallingDirection === "None") {
+        tile.fallingDirection = fallingDirection;
+        return [[x, y]];
+      } else if (
+        tileLeft.type === "Empty" &&
+        tileBelowLeft.type === "Empty"
       ) {
-        line.push([x, y, "Down"]);
+        state.setTile(
+          x - 1,
+          y + 1,
+          {
+            type: "Rock",
+            fallingDirection: getFallingDirection(state, x - 1, y + 1),
+          }
+        );
+        state.setTile(x, y, Board.EMPTY_TILE);
+
+        return [
+          [x - 1, y + 1],
+          [x, y],
+        ];
+      } else if (
+        tileRight.type === "Empty" &&
+        tileBelowRight.type === "Empty"
+      ) {
+        state.setTile(
+          x + 1,
+          y + 1,
+          {
+            type: "Rock",
+            fallingDirection: getFallingDirection(state, x + 1, y + 1),
+          }
+        );
+        state.setTile(x, y, Board.EMPTY_TILE);
+
+        return [
+          [x + 1, y + 1],
+          [x, y],
+        ];
       }
     }
-
-    if (line.length > 0) {
-      state.fallingRocks.push(line);
-    }
   }
+
+  return [];
 }
 
 /**
- * @param {State} state
- * @param {number} x
- * @param {number} y
- * @returns {[number, number, boolean]}
- */
-function applyGravityToTile(state, x, y) {
-  const direction = state.getFallingDirection(x, y);
-  if (direction === "None") {
-    return [x, y, false];
-  }
-
-  const [newX, newY] = nextCoordinateInDirection(x, y, direction);
-
-  const tile = state.board.getTile(newX, newY);
-  if (tile !== tileNames.EMPTY) {
-    if (tile === tileNames.PLAYER) {
-      state.board.setTile(newX, newY, tileNames.DEAD_PLAYER);
-    }
-
-    return [x, y, true];
-  }
-
-  state.board.setTile(x, y, tileNames.EMPTY);
-  state.board.setTile(newX, newY, tileNames.ROCK);
-
-  return [newX, newY, true];
-}
-
-/**
- * Moves all falling rocks to their next position
+ * Applies updates to each tile that needs an update
  *
  * @param {State} state
+ * @returns {Point[]} the points that were updated
  */
-export function applyGravityToFallingRocks(state) {
-  /** @type {[number, number][][]} */
-  const fallingRocks = [];
-  for (const line of state.fallingRocks) {
-    /** @type [number, number][] */
-    const newLine = [];
-    for (const [x, y, direction] of line) {
-      if (direction === "Down") {
-        const updatedTile = applyGravityToTile(state, x, y);
-        if (updatedTile[2]) {
-          newLine.push([updatedTile[0], updatedTile[1]]);
-        }
-      }
-    }
+export function applyTileUpdates(state) {
+  const sortedUpdatedTiles = reverseSortPoints(state.updatedTiles);
 
-    for (const [x, y, direction] of line) {
-      if (direction !== "Down") {
-        const updatedTile = applyGravityToTile(state, x, y);
-        if (updatedTile[2]) {
-          newLine.push([updatedTile[0], updatedTile[1]]);
-        }
-      }
-    }
+  state.updatedTiles = [];
 
-    fallingRocks.push(newLine);
+  /** @type {Point[]} */
+  const updatedPoints = [];
+  for (const point of sortedUpdatedTiles) {
+    updatedPoints.push(...updateTile(state, point[0], point[1]));
   }
 
-  state.fallingRocks = [];
-  for (const line of fallingRocks) {
-    /** @type {[number, number][]} */
-    const unprocessed = [];
-    for (const [x, y] of line) {
-      if (canFallDown(state, x, y)) {
-        state.setFallingRock(x, y, "Down");
-      } else {
-        unprocessed.push([x, y]);
-      }
-    }
-
-    for (const [x, y] of unprocessed) {
-      if (canFallLeft(state, x, y)) {
-        state.setFallingRock(x, y, "DownLeft");
-      } else if (canFallRight(state, x, y)) {
-        state.setFallingRock(x, y, "DownRight");
-      }
-    }
-  }
+  return updatedPoints;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,9 @@
     "strict": true,
     "target": "ES2020",
     "checkJs": true,
-    "allowJs": true
+    "allowJs": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
`applyGravityToFallingRocks` attempted to track and handle all falling rocks within the board as a whole. This proved very difficult to track, understand, and extend.

However, it's pretty clear that the behavior of a falling rock only depends on the tiles in its immediate neighborhood. This change switches to explicitly use this method to track and handle falling rocks. As a benefit, it also uses this method to track player state changes.