### PR TITLE
Convert logic to a state machine

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
   </body>
   <script type="module">
     import { Board, base64EncodeBoard, base64DecodeBoard, createTile } from "./src/board.js";
-    import { State, applyTileUpdates, movePlayer } from "./src/state.js";
+    import { State, applyPatternTileUpdates, movePlayer } from "./src/state.js";
 
     const tickMs = 250;
     const tileSize = 20;
@@ -63,18 +63,6 @@
 
         case "Both":
           return "B";
-
-        case "DownFromLeft":
-          return "DL";
-
-        case "DownFromRight":
-          return "DR";
-
-        case "DownFromBoth":
-          return "DB";
-
-        case "None":
-          return "N";
       }
     }
 
@@ -239,7 +227,7 @@
       }
 
       if (handled) {
-        updatedPoints.push(...applyTileUpdates(state));
+        updatedPoints.push(...applyPatternTileUpdates(state));
         renderBoard(boardElement, state.board, updatedPoints);
         renderGameState(state);
         keyboardEvent.preventDefault(); // Prevent other browser behaviors
@@ -304,7 +292,7 @@
       timerId = setInterval(
         () => {
           if (state.updatedTiles.length > 0) {
-            const updatedPoints = applyTileUpdates(state);
+            const updatedPoints = applyPatternTileUpdates(state);
             renderBoard(boardElement, state.board, updatedPoints);
             renderGameState(state);
           }

--- a/src/board.js
+++ b/src/board.js
@@ -14,10 +14,12 @@ const tileNames = {
 /**
  * @typedef GenericTile
  * @property {"Empty" | "Wall" | "Collectable" | "Dirt"} type
+ * @property {boolean} justUpdated
  *
  * @typedef PlayerTile
  * @property {"Player"} type
  * @property {boolean} isAlive
+ * @property {boolean} justUpdated
  *
  * @typedef {(
  *  "Up" |
@@ -32,32 +34,30 @@ const tileNames = {
  * @typedef RockTile
  * @property {"Rock"} type
  * @property {"Down" | "DownLeft" | "DownRight" | "None"} fallingDirection
+ * @property {boolean} justUpdated
  *
  * @typedef {(
  *  "Down" |
-*   "Left" |
-*   "Right" |
-*   "Both" |
-*   "DownFromLeft" |
-*   "DownFromRight" |
-*   "DownFromBoth" |
-*   "None"
-* )} FlowDirection
+ *  "Left" |
+ *  "Right" |
+ *  "Both"
+ * )} FlowDirection
  *
  * @typedef WaterTile
  * @property {"Water"} type
  * @property {boolean} isSource
  * @property {FlowDirection} flowDirection
+ * @property {boolean} justUpdated
  *
  * @typedef {GenericTile | PlayerTile | RockTile | WaterTile} Tile
  */
 
 export class Board {
   /** @type {Tile} */
-  static EMPTY_TILE = { type: "Empty" };
+  static EMPTY_TILE = { type: "Empty", justUpdated: false };
 
   /** @type {Tile} */
-  static WALL_TILE = { type: "Wall" };
+  static WALL_TILE = { type: "Wall", justUpdated: false };
 
   /**
    * @param {number} width
@@ -105,7 +105,7 @@ export class Board {
    */
   #validateCoordinate(x, y) {
     if (!this.isInBounds(x, y)) {
-      throw new Error("Coordinate out of bounds");
+      throw new Error(`Coordinate (${x}, ${y}) out of bounds`);
     }
   }
 
@@ -174,16 +174,21 @@ export function createTile(type) {
     case "Wall":
     case "Collectable":
     case "Dirt":
-      return { type };
+      return { type, justUpdated: false };
 
     case "Player":
-      return { type, isAlive: true };
+      return { type, isAlive: true, justUpdated: false };
 
     case "Rock":
-      return { type, fallingDirection: "None" };
+      return { type, fallingDirection: "None", justUpdated: false };
 
     case "Water":
-      return { type, isSource: true, flowDirection: "None" };
+      return {
+        type,
+        isSource: true,
+        flowDirection: "Both",
+        justUpdated: false
+      };
   }
 }
 

--- a/src/matcher.js
+++ b/src/matcher.js
@@ -1,0 +1,27 @@
+/**
+ * @typedef {import("./board.js").Tile} Tile
+ *
+ * @callback Pattern
+ * @param {Tile} tile The tile to match
+ * @returns {boolean} Whether the pattern matches
+ */
+
+/**
+ * Whether a region matches a given tile pattern
+ *
+ * @param {Tile[]} region
+ * @param {Pattern[]} pattern
+ */
+export function matcher(region, pattern) {
+  if (region.length !== pattern.length) {
+    throw new Error("region and pattern must have the same length");
+  }
+
+  for (let index = 0; index < region.length; ++index) {
+    if (!pattern[index](region[index])) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/src/patterns.js
+++ b/src/patterns.js
@@ -1,0 +1,493 @@
+/**
+ * @typedef {import("./board.js").FlowDirection} FlowDirection
+ * @typedef {import("./board.js").GenericTile} GenericTile
+ * @typedef {import("./board.js").PlayerTile} PlayerTile
+ * @typedef {import("./board.js").RockTile} RockTile
+ * @typedef {import("./board.js").Tile} Tile
+ * @typedef {import("./board.js").WaterTile} WaterTile
+ * @typedef {import("./matcher.js").Pattern} Pattern
+ */
+
+/**
+ * Matches any tile
+ *
+ * @param {Tile} _tile
+ */
+function any(_tile) {
+  return true;
+}
+
+/**
+ * Negates a pattern
+ *
+ * @param {Pattern} pattern
+ * @returns {Pattern}
+ */
+function not(pattern) {
+  return (tile) => !pattern(tile);
+}
+
+/**
+ * Ors two patterns
+ *
+ * @param {Pattern} pattern1
+ * @param {Pattern} pattern2
+ * @returns {Pattern}
+ */
+function or(pattern1, pattern2) {
+  return (tile) => pattern1(tile) || pattern2(tile);
+}
+
+/**
+ * Ands two patterns
+ *
+ * @param {Pattern} pattern1
+ * @param {Pattern} pattern2
+ * @returns {Pattern}
+ */
+function and(pattern1, pattern2) {
+  return (tile) => pattern1(tile) && pattern2(tile);
+}
+
+/**
+ * Matches a partial tile
+ *
+ * @param {Partial<Tile> & Pick<Tile, "type">} patternTile
+ * @returns {Pattern}
+ */
+function isTile(patternTile) {
+  return (tile) => {
+    if (tile.type !== patternTile.type) {
+      return false;
+    }
+
+    if (tile.type === "Water" && patternTile.type === "Water") {
+      if (
+        (patternTile.isSource !== undefined) &&
+        (tile.isSource !== patternTile.isSource)
+      ) {
+        return false;
+      }
+
+      if (
+        (patternTile.flowDirection !== undefined) &&
+        (tile.flowDirection !== patternTile.flowDirection)
+      ) {
+        return false;
+      }
+    }
+
+    return true;
+  };
+}
+
+/**
+ * Whether a tile was just updated
+ *
+ * @param {Tile} tile
+ */
+function wasJustUpdated(tile) {
+  return tile.justUpdated;
+}
+
+/**
+ * Whether a tile behaves as if it were empty for a rock
+ *
+ * @param {Tile} tile
+ */
+function isEmptyForRock(tile) {
+  return tile.type === "Empty" || tile.type === "Water";
+}
+
+/**
+ * Whether a rock is falling
+ *
+ * @param {Tile} tile
+ */
+function isFallingRock(tile) {
+  return tile.type === "Rock" && tile.fallingDirection !== "None";
+}
+
+/**
+ * Whether a tile supports a particular flow direction
+ *
+ * @param {FlowDirection} flowDirection
+ * @returns {Pattern}
+ */
+function supportsFlowDirection(flowDirection) {
+  return (tile) =>
+    (tile.type === "Water") && (
+      tile.isSource || (tile.flowDirection === flowDirection) ||
+      (tile.flowDirection === "Both")
+    );
+}
+
+/**
+ * Whether a tile is a non-source flowing water with a specific direction
+ *
+ * @param {FlowDirection} flowDirection
+ * @returns {Pattern}
+ */
+function isFlowingWater(flowDirection) {
+  return (tile) =>
+    (tile.type === "Water") &&
+    (tile.flowDirection === flowDirection) &&
+    !tile.isSource;
+}
+
+/**
+ * Whether a tile behaves as if it were solid for water
+ *
+ * @param {Tile} tile
+ */
+function isSolidForWater(tile) {
+  return tile.type !== "Empty" && tile.type !== "Water";
+}
+
+/**
+ * Whether a player is alive
+ *
+ * @param {Tile} tile
+ */
+function isLivingPlayer(tile) {
+  return tile.type === "Player" && tile.isAlive;
+}
+
+/**
+ * @typedef {(
+ *   Omit<GenericTile, "justUpdated"> |
+ *   Omit<PlayerTile, "justUpdated"> |
+ *   Omit<RockTile, "justUpdated"> |
+ *   Omit<WaterTile, "justUpdated"> |
+ *   null
+ * )} TileUpdate
+ */
+
+/**
+ * Applies a tile update
+ *
+ * @param {Tile} tile
+ * @param {TileUpdate} tileUpdate
+ */
+export function applyTileUpdate(tile, tileUpdate) {
+  return tileUpdate ? { ...tileUpdate, justUpdated: true } : tile;
+}
+
+/**
+ * @typedef {[
+ *   Pattern, Pattern, Pattern,
+ *   Pattern, Pattern, Pattern,
+ *   Pattern, Pattern, Pattern
+ * ]} PatternRegion
+ * @typedef {[
+ *   TileUpdate, TileUpdate, TileUpdate,
+ *   TileUpdate, TileUpdate, TileUpdate,
+ *   TileUpdate, TileUpdate, TileUpdate
+ * ]} TileUpdateRegion
+ */
+
+/** @type {[PatternRegion, TileUpdateRegion][]} */
+export const patterns = [
+  // Rocks fall down
+  [
+    [
+      any, any, any,
+      any, isTile({ type: "Rock" }), any,
+      any, isEmptyForRock, any,
+    ],
+    [
+      null, null, null,
+      null, { type: "Empty" }, null,
+      null, { type: "Rock", fallingDirection: "Down" }, null,
+    ],
+  ],
+  // Rocks that fall down kill players and stop
+  [
+    [
+      any, any, any,
+      any, isFallingRock, any,
+      any, isLivingPlayer, any,
+    ],
+    [
+      null, null, null,
+      null, { type: "Rock", fallingDirection: "None" }, null,
+      null, { type: "Player", isAlive: false }, null,
+    ],
+  ],
+  // Rocks wait for other falling rocks to fall left off a rock below them
+  [
+    [
+      any, any, any,
+      isFallingRock, isFallingRock, any,
+      or(isEmptyForRock, isFallingRock), isTile({ type: "Rock" }), any,
+    ],
+    [
+      null, null, null,
+      null, { type: "Rock", fallingDirection: "DownLeft" }, null,
+      null, null, null,
+    ],
+  ],
+  // Rocks wait for other falling rocks to fall left off a rock below them
+  [
+    [
+      any, any, any,
+      any, isFallingRock, any,
+      isFallingRock, isTile({ type: "Rock" }), any,
+    ],
+    [
+      null, null, null,
+      null, { type: "Rock", fallingDirection: "DownLeft" }, null,
+      null, null, null,
+    ],
+  ],
+  // Rocks wait for other falling rocks to fall right off a rock below them
+  [
+    [
+      any, any, any,
+      not(isEmptyForRock), isFallingRock, isFallingRock,
+      any, isTile({ type: "Rock" }), or(isEmptyForRock, isFallingRock),
+    ],
+    [
+      null, null, null,
+      null, { type: "Rock", fallingDirection: "DownRight" }, null,
+      null, null, null,
+    ],
+  ],
+  // Rocks wait for other falling rocks to fall right off a rock below them
+  [
+    [
+      any, any, any,
+      not(isEmptyForRock), isFallingRock, any,
+      any, isTile({ type: "Rock" }), isFallingRock,
+    ],
+    [
+      null, null, null,
+      null, { type: "Rock", fallingDirection: "DownRight" }, null,
+      null, null, null,
+    ],
+  ],
+  // Rocks fall left off a hard surface
+  [
+    [
+      any, any, any,
+      isEmptyForRock, isFallingRock, any,
+      isEmptyForRock, not(isEmptyForRock), any,
+    ],
+    [
+      null, null, null,
+      null, { type: "Empty" }, null,
+      { type: "Rock", fallingDirection: "DownLeft" }, null, null,
+    ],
+  ],
+  // Rocks falling left kill a player and stop
+  [
+    [
+      any, any, any,
+      isEmptyForRock, isFallingRock, any,
+      isLivingPlayer, not(isEmptyForRock), any,
+    ],
+    [
+      null, null, null,
+      null, { type: "Rock", fallingDirection: "None" }, null,
+      { type: "Player", isAlive: false }, null, null,
+    ],
+  ],
+  // Rocks fall right off a hard surface
+  [
+    [
+      any, any, any,
+      any, isFallingRock, isEmptyForRock,
+      any, not(isEmptyForRock), isEmptyForRock,
+    ],
+    [
+      null, null, null,
+      null, { type: "Empty" }, null,
+      null, null, { type: "Rock", fallingDirection: "DownRight" },
+    ],
+  ],
+  // Rocks falling right kill a player and stop
+  [
+    [
+      any, any, any,
+      any, isFallingRock, isEmptyForRock,
+      any, not(isEmptyForRock), isLivingPlayer,
+    ],
+    [
+      null, null, null,
+      null, { type: "Rock", fallingDirection: "None" }, null,
+      null, null, { type: "Player", isAlive: false },
+    ],
+  ],
+  // Falling rocks stop if there is no where to fall
+  [
+    [
+      any, any, any,
+      any, isFallingRock, any,
+      not(isEmptyForRock), not(isEmptyForRock), not(isEmptyForRock),
+    ],
+    [
+      null, null, null,
+      null, { type: "Rock", fallingDirection: "None" }, null,
+      null, null, null,
+    ],
+  ],
+  // Water flows down
+  [
+    [
+      any, isTile({ type: "Water" }), any,
+      any, isTile({ type: "Empty" }), any,
+      any, isTile({ type: "Empty" }), any,
+    ],
+    [
+      null, null, null,
+      null, { type: "Water", isSource: false, flowDirection: "Down" }, null,
+      null, null, null,
+    ],
+  ],
+  // Water onto a surface
+  [
+    [
+      any, isTile({ type: "Water" }), any,
+      any, isTile({ type: "Empty" }), any,
+      any, isSolidForWater, any,
+    ],
+    [
+      null, null, null,
+      null, { type: "Water", isSource: false, flowDirection: "Both" }, null,
+      null, null, null,
+    ],
+  ],
+  // Down-ward flowing water converts to both when a surface is below it
+  [
+    [
+      any, any, any,
+      any, isFlowingWater("Down"), any,
+      any, isSolidForWater, any,
+    ],
+    [
+      null, null, null,
+      null, { type: "Water", isSource: false, flowDirection: "Both" }, null,
+      null, null, null,
+    ],
+  ],
+  // Both-ward flowing water converts to down when no surface is below it
+  [
+    [
+      any, any, any,
+      any, isFlowingWater("Both"), any,
+      any, not(isSolidForWater), any,
+    ],
+    [
+      null, null, null,
+      null, { type: "Water", isSource: false, flowDirection: "Down" }, null,
+      null, null, null,
+    ],
+  ],
+  // Down-flowing water kills a player
+  [
+    [
+      any, any, any,
+      any, isTile({ type: "Water" }), any,
+      any, isLivingPlayer, any,
+    ],
+    [
+      null, null, null,
+      null, null, null,
+      null, { type: "Player", isAlive: false }, null,
+    ],
+  ],
+  // Water spreads right
+  [
+    [
+      any, any, any,
+      any, supportsFlowDirection("Right"), isTile({ type: "Empty" }),
+      any, isSolidForWater, any,
+    ],
+    [
+      null, null, null,
+      null, null, { type: "Water", isSource: false, flowDirection: "Right" },
+      null, null, null,
+    ],
+  ],
+  // Right-flowing water kills a player
+  [
+    [
+      any, any, any,
+      any, isTile({ type: "Water" }), isLivingPlayer,
+      any, isSolidForWater, any,
+    ],
+    [
+      null, null, null,
+      null, null, { type: "Player", isAlive: false },
+      null, null, null,
+    ],
+  ],
+  // Water spreads left
+  [
+    [
+      any, any, any,
+      any, isTile({ type: "Empty" }), and(supportsFlowDirection("Left"), not(wasJustUpdated)),
+      any, any, isSolidForWater,
+    ],
+    [
+      null, null, null,
+      null, { type: "Water", isSource: false, flowDirection: "Left" }, null,
+      null, null, null,
+    ],
+  ],
+  // Left-flowing water kills a player
+  [
+    [
+      any, any, any,
+      any, isLivingPlayer, and(isTile({ type: "Water" }), not(wasJustUpdated)),
+      any, any, isSolidForWater,
+    ],
+    [
+      null, null, null,
+      null, { type: "Player", isAlive: false }, null,
+      null, null, null,
+    ],
+  ],
+  // Both-flowing and down-flowing water dries if it doesn't have a source or
+  // down-flowing water above it
+  [
+    [
+      any, not(isTile({ type: "Water" })), any,
+      any, or(isFlowingWater("Both"), isFlowingWater("Down")), any,
+      any, any, any,
+    ],
+    [
+      null, null, null,
+      null, { type: "Empty" }, null,
+      null, null, null,
+    ],
+  ],
+  // Right-flowing water dries if it doesn't have a source or right-flowing
+  // water to its right
+  [
+    [
+      any, any, any,
+      not(supportsFlowDirection("Right")), isFlowingWater("Right"), any,
+      any, any, any,
+    ],
+    [
+      null, null, null,
+      null, { type: "Empty" }, null,
+      null, null, null,
+    ],
+  ],
+  // Left-flowing water dries if it doesn't have a source or left-flowing
+  // water to its left
+  [
+    [
+      any, any, any,
+      any, isFlowingWater("Left"), and(not(supportsFlowDirection("Left")), not(wasJustUpdated)),
+      any, any, any,
+    ],
+    [
+      null, null, null,
+      null, { type: "Empty" }, null,
+      null, null, null,
+    ],
+  ],
+];

--- a/src/state.js
+++ b/src/state.js
@@ -1,9 +1,12 @@
 import { Board } from "./board.js";
+import { matcher } from "./matcher.js";
+import { patterns, applyTileUpdate } from "./patterns.js";
 
 /**
  * @typedef {import("./board.js").Direction} Direction
  * @typedef {import("./board.js").FlowDirection} FlowDirection
  * @typedef {import("./board.js").Tile} Tile
+ * @typedef {import("./patterns.js").TileUpdate} TileUpdate
  * @typedef {[number, number]} Point
  */
 
@@ -59,6 +62,14 @@ export class State {
     for (let y = this.board.height - 1; y >= 0; --y) {
       for (let x = this.board.width - 1; x >= 0; --x) {
         this.updatedTiles.push([x, y]);
+      }
+    }
+  }
+
+  clearJustUpdated() {
+    for (let y = 0; y < this.board.height; ++y) {
+      for (let x = 0; x < this.board.width; ++x) {
+        this.board.getTile(x, y).justUpdated = false;
       }
     }
   }
@@ -239,361 +250,58 @@ function reverseSortPoints(points) {
 }
 
 /**
- * Gets the falling direction for a rock at a given point
+ * Gets the 3x3 region centered at a given point
+ *
+ * @param {Board} board
+ * @param {Point} point
+ */
+function getPointCenteredRegion(board, point) {
+  return [
+    board.getTile(point[0] - 1, point[1] - 1),
+    board.getTile(point[0], point[1] - 1),
+    board.getTile(point[0] + 1, point[1] - 1),
+    board.getTile(point[0] - 1, point[1]),
+    board.getTile(point[0], point[1]),
+    board.getTile(point[0] + 1, point[1]),
+    board.getTile(point[0] - 1, point[1] + 1),
+    board.getTile(point[0], point[1] + 1),
+    board.getTile(point[0] + 1, point[1] + 1),
+  ];
+}
+
+/**
  *
  * @param {State} state
- * @param {number} x
- * @param {number} y
- * @returns {"Down" | "DownLeft" | "DownRight" | "None"}
+ * @param {Point} point
+ * @param {TileUpdate[]} updates
  */
-function getFallingDirection(state, x, y) {
-  const tileBelow = state.board.getTile(x, y + 1);
-  if (canRockMoveThrough(tileBelow)) {
-    return "Down";
-  } else if (tileBelow.type === "Rock") {
-    const tileLeft = state.board.getTile(x - 1, y);
-    const tileBelowLeft = state.board.getTile(x - 1, y + 1);
-    if (canRockMoveThrough(tileLeft) && canRockMoveThrough(tileBelowLeft)) {
-      return "DownLeft";
-    }
+function applyRegionUpdates(state, point, updates) {
+  /** @type {Point[]} */
+  const updatedPoints = [];
 
-    const tileRight = state.board.getTile(x + 1, y);
-    const tileBelowRight = state.board.getTile(x + 1, y + 1);
-    if (canRockMoveThrough(tileRight) && canRockMoveThrough(tileBelowRight)) {
-      return "DownRight";
-    }
-  }
+  for (let y = -1; y < 2; ++y) {
+    for (let x = -1; x < 2; ++x) {
+      const update = updates[(x + 1) + 3 * (y + 1)];
 
-  return "None";
-}
+      /** @type {Point} */
+      const currentPoint = [point[0] + x, point[1] + y];
 
-/**
- * Whether a tile behaves as if it were solid for water
- *
- * @param {Tile} tile
- */
-function isSolidForWater(tile) {
-  return tile.type !== "Empty" && tile.type !== "Water";
-}
+      if (update) {
+        updatedPoints.push(currentPoint);
 
-/**
- * Whether a flow direction is down
- *
- * @param {FlowDirection} flowDirection
- */
-function isFlowingDown(flowDirection) {
-  return flowDirection === "Down" ||
-    flowDirection === "DownFromBoth" ||
-    flowDirection === "DownFromLeft" ||
-    flowDirection === "DownFromRight";
-}
-
-/**
- * Whether a flow direction is left
- *
- * @param {FlowDirection} flowDirection
- */
-function isFlowingLeft(flowDirection) {
-  return flowDirection === "Left" || flowDirection === "Both";
-}
-
-/**
- * Whether a flow direction is right
- *
- * @param {FlowDirection} flowDirection
- */
-function isFlowingRight(flowDirection) {
-  return flowDirection === "Right" || flowDirection === "Both";
-}
-
-/**
- * Whether a water tile has an input of water which can sustain its flow
- * @param {State} state
- * @param {number} x
- * @param {number} y
- */
-function canSustainFlow(state, x, y) {
-  const tile = state.board.getTile(x, y);
-  if (tile.type !== "Water") {
-    return false;
-  }
-
-  if (tile.isSource) {
-    return true;
-  }
-
-  const tileAbove = state.board.getTile(x, y - 1);
-  if (tileAbove.type === "Water") {
-    return true;
-  }
-
-  const tileLeft = state.board.getTile(x - 1, y);
-  if (tileLeft.type === "Water" && isFlowingRight(tileLeft.flowDirection)) {
-    return true;
-  }
-
-  const tileRight = state.board.getTile(x + 1, y);
-  if (tileRight.type === "Water" && isFlowingLeft(tileRight.flowDirection)) {
-    return true;
-  }
-
-  return false;
-}
-
-/**
- * Gets the flowing direction for water at a given point
- *
- * @param {State} state
- * @param {number} x
- * @param {number} y
- * @returns {FlowDirection}
- */
-function getFlowDirection(state, x, y) {
-  const tile = state.board.getTile(x, y)
-  if (tile.type !== "Water") {
-    return "None";
-  }
-
-  const tileBelow = state.board.getTile(x, y + 1);
-  const tileLeft = state.board.getTile(x - 1, y);
-  const tileRight = state.board.getTile(x + 1, y);
-  if (isSolidForWater(tileBelow)) {
-    if (isSolidForWater(tileLeft) && isSolidForWater(tileRight)) {
-      return "None";
-    } else if (isSolidForWater(tileLeft) && !(tileRight.type === "Water" && isFlowingLeft(tileRight.flowDirection))) {
-      return "Right";
-    } else if (isSolidForWater(tileRight) && !(tileLeft.type === "Water" && isFlowingRight(tileLeft.flowDirection))) {
-      return "Left";
-    }
-
-    const tileAbove = state.board.getTile(x, y - 1);
-    if (tile.isSource || tileAbove.type === "Water") {
-      return "Both";
-    } else if (tileLeft.type === "Water" && isFlowingRight(tileLeft.flowDirection)) {
-      return "Right";
-    } else if (tileRight.type === "Water" && isFlowingLeft(tileRight.flowDirection)) {
-      return "Left";
-    }
-
-    return "None";
-  }
-
-  if (tile.isSource) {
-    return "Down";
-  } else if (tileLeft.type === "Water" && tileRight.type === "Water") {
-    return "DownFromBoth";
-  } else if (tileLeft.type === "Water") {
-    return "DownFromRight";
-  } else if (tileRight.type === "Water") {
-    return "DownFromLeft";
-  }
-
-  return "Down";
-}
-
-/**
- * Updates state to account for flowing water
- *
- * @param {State} state
- * @param {number} x
- * @param {number} y
- * @param {FlowDirection} flowDirection
- * @returns {Point[]} the points that were updated
- */
-function flowWater(state, x, y, flowDirection) {
-  if (isFlowingDown(flowDirection)) {
-    const tileBelow = state.board.getTile(x, y + 1);
-    if (tileBelow.type === "Empty") {
-      state.setTile(
-        x,
-        y + 1,
-        {
-          type: "Water",
-          isSource: false,
-          flowDirection: "Down",
-        }
-      );
-
-      return [
-        [x, y + 1],
-      ];
-    }
-  }
-
-  if (isFlowingLeft(flowDirection)) {
-    const tileLeft = state.board.getTile(x - 1, y);
-    if (tileLeft.type === "Empty") {
-      state.setTile(
-        x - 1,
-        y,
-        {
-          type: "Water",
-          isSource: false,
-          flowDirection: "Left",
-        }
-      );
-
-      return [
-        [x - 1, y],
-      ];
-    }
-  }
-
-  if (isFlowingRight(flowDirection)) {
-    const tileRight = state.board.getTile(x + 1, y);
-    if (tileRight.type === "Empty") {
-      state.setTile(
-        x + 1,
-        y,
-        {
-          type: "Water",
-          isSource: false,
-          flowDirection: "Right",
-        }
-      );
-
-      return [
-        [x + 1, y],
-      ];
-    }
-  }
-
-  return [];
-}
-
-/**
- * Updates a single tile based on the region around it
- *
- * @param {State} state
- * @param {number} x
- * @param {number} y
- * @returns {Point[]} the points that were updated
- */
-function updateTile(state, x, y) {
-  const tile = state.board.getTile(x, y);
-  const tileAbove = state.board.getTile(x, y - 1);
-  const tileAboveRight = state.board.getTile(x + 1, y - 1);
-  const tileAboveLeft = state.board.getTile(x - 1, y - 1);
-  const tileLeft = state.board.getTile(x - 1, y);
-  const tileRight = state.board.getTile(x + 1, y);
-  const tileBelow = state.board.getTile(x, y + 1);
-  const tileBelowRight = state.board.getTile(x + 1, y + 1);
-  const tileBelowLeft = state.board.getTile(x - 1, y + 1);
-  if (tile.type === "Player") {
-    if (
-      (tileAbove.type === "Rock" && tileAbove.fallingDirection === "Down") ||
-      (
-        tileAboveLeft.type === "Rock" &&
-        tileAboveLeft.fallingDirection === "DownRight"
-      ) ||
-      (
-        tileAboveRight.type === "Rock" &&
-        tileAboveRight.fallingDirection === "DownLeft"
-      ) ||
-      (tileAbove.type === "Water") ||
-      (tileRight.type === "Water" && !isFlowingLeft(tileRight.flowDirection)) ||
-      (tileLeft.type === "Water" && !isFlowingRight(tileLeft.flowDirection))
-    ) {
-      tile.isAlive = false;
-      return [[x, y]];
-    }
-  } else if (tile.type === "Rock") {
-    if (isEmptyForRock(tileBelow)) {
-      state.setTile(
-        x,
-        y + 1,
-        {
-          type: "Rock",
-          fallingDirection: getFallingDirection(state, x, y + 1),
-        }
-      );
-      state.setTile(x, y, Board.EMPTY_TILE);
-
-      return [
-        [x, y + 1],
-        [x, y],
-      ];
-    } else if (
-      tile.fallingDirection !== "None" &&
-      tileBelow.type === "Rock" &&
-      tileBelow.fallingDirection === "None"
-    ) {
-      const fallingDirection = getFallingDirection(state, x, y);
-      if (fallingDirection === "None") {
-        tile.fallingDirection = fallingDirection;
-        return [[x, y]];
-      } else if (
-        tileLeft.type === "Empty" &&
-        tileBelowLeft.type === "Empty"
-      ) {
         state.setTile(
-          x - 1,
-          y + 1,
-          {
-            type: "Rock",
-            fallingDirection: getFallingDirection(state, x - 1, y + 1),
-          }
+          currentPoint[0],
+          currentPoint[1],
+          applyTileUpdate(
+            state.board.getTile(currentPoint[0], currentPoint[1]),
+            update
+          )
         );
-        state.setTile(x, y, Board.EMPTY_TILE);
-
-        return [
-          [x - 1, y + 1],
-          [x, y],
-        ];
-      } else if (
-        tileRight.type === "Empty" &&
-        tileBelowRight.type === "Empty"
-      ) {
-        state.setTile(
-          x + 1,
-          y + 1,
-          {
-            type: "Rock",
-            fallingDirection: getFallingDirection(state, x + 1, y + 1),
-          }
-        );
-        state.setTile(x, y, Board.EMPTY_TILE);
-
-        return [
-          [x + 1, y + 1],
-          [x, y],
-        ];
       }
     }
-  } else if (tile.type === "Water") {
-    if (!canSustainFlow(state, x, y)) {
-      state.setTile(x, y, Board.EMPTY_TILE);
-
-      return [
-        [x, y],
-      ];
-    }
-
-    const flowDirection = getFlowDirection(state, x, y);
-
-    /** @type {Point[]} */
-    const updatedPoints = [];
-    if (flowDirection !== tile.flowDirection) {
-      tile.flowDirection = flowDirection;
-
-      updatedPoints.push([x, y]);
-    }
-
-    updatedPoints.push(...flowWater(state, x, y, flowDirection));
-    return updatedPoints;
   }
 
-  return [];
-}
-
-/**
- * Whether two points are equal
- *
- * @param {Point} u
- * @param {Point} v
- */
-function arePointsEqual(u, v) {
-  return u[0] === v[0] && u[1] === v[1];
+  return updatedPoints;
 }
 
 /**
@@ -602,7 +310,7 @@ function arePointsEqual(u, v) {
  * @param {State} state
  * @returns {Point[]} the points that were updated
  */
-export function applyTileUpdates(state) {
+export function applyPatternTileUpdates(state) {
   const sortedUpdatedTiles = reverseSortPoints(state.updatedTiles);
 
   state.updatedTiles = [];
@@ -610,10 +318,16 @@ export function applyTileUpdates(state) {
   /** @type {Point[]} */
   const updatedPoints = [];
   for (const point of sortedUpdatedTiles) {
-    if (!updatedPoints.some(updatedPoint => arePointsEqual(updatedPoint, point))) {
-      updatedPoints.push(...updateTile(state, point[0], point[1]));
+    const region = getPointCenteredRegion(state.board, point);
+    for (const [pattern, updates] of patterns) {
+      if (matcher(region, pattern)) {
+        updatedPoints.push(...applyRegionUpdates(state, point, updates));
+        break;
+      }
     }
   }
+
+  state.clearJustUpdated();
 
   return updatedPoints;
 }


### PR DESCRIPTION
At its core, this program can be run as a state machine. Until now it seemed simpler to write the logic more procedurally but adding water proved difficult to conceptualize because it was difficult to see the various cases and interactions in the procedural logic.

This change moves to a state machine with a pattern matcher and transition function to make the large number of possible states more manageable. It is now much easier to see the various states and confirm the transitions make sense. Debugging this has also been much easier.

More tests are added because the transitions make it clearer what needs to be tested.

Each tile now also tracks if it was updated in the current cycle in order to ensure states that update tiles to their left don't update too quickly.