### PR TITLE
Add conveyors

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
           <input id="heightInput" type="number" min="1" max="64" value="10">
         </div>
         <div>
+          <label for="selectedTile">Tile</label>
           <select id="selectedTile">
             <option value="Empty" selected>Empty</option>
             <option value="Wall">Wall</option>
@@ -31,6 +32,14 @@
             <option value="Dirt">Dirt</option>
             <option value="Player">Player</option>
             <option value="Water">Water</option>
+          </select>
+          <label for="selectedConveyorDirection">Conveyor Direction</label>
+          <select id="selectedConveyorDirection">
+            <option value="None" selected>None</option>
+            <option value="Down">Down</option>
+            <option value="Left">Left</option>
+            <option value="Right">Right</option>
+            <option value="Up">Up</option>
           </select>
         </div>
         <div>
@@ -70,6 +79,39 @@
       }
     }
 
+    function drawArrow(context, x, y, width, height, direction) {
+      context.save();
+
+      context.translate(x + width / 2, y + height / 2);
+      switch (direction) {
+        case "Left":
+          context.rotate(Math.PI / 2);
+          break;
+
+        case "Right":
+          context.rotate(-Math.PI / 2);
+          break;
+
+        case "Up":
+          context.rotate(Math.PI);
+          break;
+      }
+      context.scale(0.75, 0.75);
+
+      context.lineWidth = 2;
+      context.strokeStyle = "grey";
+
+      context.beginPath();
+      context.moveTo(0, -height / 2);
+      context.lineTo(0, height / 2);
+      context.lineTo(-width / 2, 0);
+      context.moveTo(0, height / 2);
+      context.lineTo(width / 2, 0);
+      context.stroke();
+
+      context.restore();
+    }
+
     function drawTile(context, tile, x, y, width, height) {
       context.save();
 
@@ -107,6 +149,24 @@
         width,
         height
       );
+
+      switch (tile.conveyorDirection) {
+        case "Down":
+          drawArrow(context, x, y, width, height, "Down");
+          break;
+
+        case "Left":
+          drawArrow(context, x, y, width, height, "Left");
+          break;
+
+        case "Right":
+          drawArrow(context, x, y, width, height, "Right");
+          break;
+
+        case "Up":
+          drawArrow(context, x, y, width, height, "Up");
+          break;
+      }
 
       if (tile.type === "Water") {
         const text = getFlowDirectionText(tile.flowDirection);
@@ -156,19 +216,40 @@
         case "Empty":
         case "Wall":
         case "Collectable":
-          return { type, justUpdated: false };
+          return { type, justUpdated: false, conveyorDirection };
 
         case "Dirt":
-          return { type, flowDirection: "None", justUpdated: false };
+          return {
+            type,
+            flowDirection: "None",
+            justUpdated: false,
+            conveyorDirection,
+          };
 
         case "Player":
-          return { type, isAlive: true, justUpdated: false };
+          return {
+            type,
+            isAlive: true,
+            justUpdated: false,
+            conveyorDirection,
+          };
 
         case "Rock":
-          return { type, fallingDirection: "None", justUpdated: false };
+          return {
+            type,
+            fallingDirection: "None",
+            justUpdated: false,
+            conveyorDirection,
+          };
 
         case "Water":
-          return { type, flowDirection: "All", justUpdated: false };
+          return {
+            type,
+            isSource: true,
+            flowDirection: "Both",
+            justUpdated: false,
+            conveyorDirection,
+          };
       }
     }
 
@@ -182,8 +263,14 @@
       const tile = selectedTileInput.selectedOptions[0].value;
       const originalTile = board.getTile(tileX, tileY);
 
-      if (tile !== originalTile.type) {
-        board.setTile(tileX, tileY, createTile(tile));
+      const conveyorDirection =
+        selectedConveyorDirectionInput.selectedOptions[0].value;
+
+      if (
+        (tile !== originalTile.type) ||
+        (conveyorDirection !== originalTile.conveyorDirection)
+      ) {
+        board.setTile(tileX, tileY, createTile(tile, conveyorDirection));
         generatedBoardOutput.value = encodeBoard(board);
         renderBoard(boardElement, board, [[tileX, tileY]]);
       }
@@ -193,6 +280,8 @@
     const widthInput = document.getElementById("widthInput");
     const heightInput = document.getElementById("heightInput");
     const selectedTileInput = document.getElementById("selectedTile");
+    const selectedConveyorDirectionInput =
+      document.getElementById("selectedConveyorDirection");
     const generatedBoardOutput = document.getElementById("generatedBoard");
     const buildButton = document.getElementById("build");
     const playButton = document.getElementById("play");

--- a/src/board.js
+++ b/src/board.js
@@ -6,10 +6,18 @@ import { decodeTile, encodeTile } from "./tile.js";
 
 export class Board {
   /** @type {Tile} */
-  static EMPTY_TILE = { type: "Empty", justUpdated: false };
+  static EMPTY_TILE = {
+    type: "Empty",
+    justUpdated: false,
+    conveyorDirection: "None",
+  };
 
   /** @type {Tile} */
-  static WALL_TILE = { type: "Wall", justUpdated: false };
+  static WALL_TILE = {
+    type: "Wall",
+    justUpdated: false,
+    conveyorDirection: "None",
+  };
 
   /**
    * @param {number} width

--- a/src/state.js
+++ b/src/state.js
@@ -4,6 +4,8 @@ import { patterns, applyTileUpdate } from "./patterns.js";
 
 /**
  * @typedef {import("./tile.js").Direction} Direction
+ * @typedef {import("./tile.js").PlayerTile} PlayerTile
+ * @typedef {import("./tile.js").RockTile} RockTile
  * @typedef {import("./tile.js").Tile} Tile
  * @typedef {import("./patterns.js").TileUpdate} TileUpdate
  * @typedef {[number, number]} Point
@@ -239,8 +241,23 @@ export function movePlayer(state, direction) {
         ++state.collected;
       }
 
-      state.setTile(x, y, Board.EMPTY_TILE);
-      state.setTile(newX, newY, playerTile);
+      /** @type {Tile} */
+      const newEmptyTile = {
+        type: "Empty",
+        justUpdated: false,
+        conveyorDirection: playerTile.conveyorDirection,
+      };
+
+      /** @type {PlayerTile} */
+      const newPlayerTile = {
+        type: "Player",
+        isAlive: true,
+        justUpdated: false,
+        conveyorDirection: tile.conveyorDirection,
+      };
+
+      state.setTile(x, y, newEmptyTile);
+      state.setTile(newX, newY, newPlayerTile);
 
       updatedPoints.push([x, y]);
       updatedPoints.push([newX, newY]);
@@ -251,7 +268,16 @@ export function movePlayer(state, direction) {
           newY,
           direction
         );
-        state.setTile(nextX, nextY, tile);
+        const nextTile = state.board.getTile(nextX, nextY);
+
+        /** @type {RockTile} */
+        const newRockTile = {
+          type: "Rock",
+          fallingDirection: "None",
+          justUpdated: false,
+          conveyorDirection: nextTile.conveyorDirection,
+        }
+        state.setTile(nextX, nextY, newRockTile);
         updatedPoints.push([nextX, nextY]);
       }
     }

--- a/src/tile.js
+++ b/src/tile.js
@@ -1,12 +1,22 @@
 /**
+ * @typedef {(
+ *  "Down" |
+ *  "Left" |
+ *  "Right" |
+ *  "Up" |
+ *  "None"
+ * )} ConveyorDirection
+ *
  * @typedef GenericTile
  * @property {"Empty" | "Wall" | "Collectable"} type
  * @property {boolean} justUpdated
+ * @property {ConveyorDirection} conveyorDirection
  *
  * @typedef PlayerTile
  * @property {"Player"} type
  * @property {boolean} isAlive
  * @property {boolean} justUpdated
+ * @property {ConveyorDirection} conveyorDirection
  *
  * @typedef {(
  *  "Up" |
@@ -22,6 +32,7 @@
  * @property {"Rock"} type
  * @property {"Down" | "DownLeft" | "DownRight" | "None"} fallingDirection
  * @property {boolean} justUpdated
+ * @property {ConveyorDirection} conveyorDirection
  *
  * @typedef {(
  *  "Down" |
@@ -34,14 +45,98 @@
  * @property {"Water"} type
  * @property {FlowDirection | "All"} flowDirection
  * @property {boolean} justUpdated
+ * @property {ConveyorDirection} conveyorDirection
  *
  * @typedef DirtTile
  * @property {"Dirt"} type
  * @property {FlowDirection | "None"} flowDirection
  * @property {boolean} justUpdated
+ * @property {ConveyorDirection} conveyorDirection
  *
  * @typedef {DirtTile | GenericTile | PlayerTile | RockTile | WaterTile} Tile
  */
+
+/**
+ * Appends the conveyor direction to an encoded tile
+ *
+ * @param {ConveyorDirection} conveyorDirection
+ * @param {string} encoded
+ * @returns {string}
+ */
+function appendConveyorDirection(conveyorDirection, encoded) {
+  switch (conveyorDirection) {
+    case "Down":
+      return encoded + "v";
+
+    case "Left":
+      return encoded + "<";
+
+    case "None":
+      return encoded;
+
+    case "Right":
+      return encoded + ">";
+
+    case "Up":
+      return encoded + "^";
+  }
+}
+
+/**
+ * Decodes a conveyor direction from an array of characters
+ *
+ * @param {Omit<Tile, "conveyorDirection">} partialTile
+ * @param {string[]} chars
+ * @param {number} index The index in the array to decode from
+ * @returns {{ tile: Tile, nextIndex: number }}
+ */
+function decodeConveyorDirection(partialTile, chars, index) {
+  switch (chars[index]) {
+    case "v":
+      return {
+        tile: /** @type {Tile} */ ({
+          ...partialTile,
+          conveyorDirection: "Down",
+        }),
+        nextIndex: index + 1,
+      };
+
+    case "<":
+      return {
+        tile: /** @type {Tile} */ ({
+          ...partialTile,
+          conveyorDirection: "Left",
+        }),
+        nextIndex: index + 1,
+      };
+
+    case ">":
+      return {
+        tile: /** @type {Tile} */ ({
+          ...partialTile,
+          conveyorDirection: "Right",
+        }),
+        nextIndex: index + 1,
+      };
+
+    case "^":
+      return {
+        tile: /** @type {Tile} */ ({
+          ...partialTile,
+          conveyorDirection: "Up",
+        }),
+        nextIndex: index + 1,
+      };
+  }
+
+  return {
+    tile: /** @type {Tile} */ ({
+      ...partialTile,
+      conveyorDirection: "None",
+    }),
+    nextIndex: index,
+  };
+}
 
 /**
  * Encodes a generic tile
@@ -67,10 +162,10 @@ function encodeGenericTile(tile) {
  *
  * @param {string[]} chars
  * @param {number} index The index in the array to decode from
- * @returns {{ tile: GenericTile, nextIndex: number }}
+ * @returns {{ tile: Omit<GenericTile, "conveyorDirection">, nextIndex: number }}
  */
 function decodeGenericTile(chars, index) {
-  /** @type {GenericTile} */
+  /** @type {Omit<GenericTile, "conveyorDirection">} */
   let tile;
   switch (chars[index]) {
     case "C":
@@ -122,12 +217,12 @@ function encodeDirtTile(tile) {
  *
  * @param {string[]} chars
  * @param {number} index The index in the array to decode from
- * @returns {{ tile: DirtTile, nextIndex: number }}
+ * @returns {{ tile: Omit<DirtTile, "conveyorDirection">, nextIndex: number }}
  */
 function decodeDirtTile(chars, index) {
   const flowDirection = chars[index + 1];
 
-  /** @type {DirtTile} */
+  /** @type {Omit<DirtTile, "conveyorDirection">} */
   let tile;
   switch (flowDirection) {
     case "_":
@@ -174,12 +269,12 @@ function encodePlayerTile(tile) {
  *
  * @param {string[]} chars
  * @param {number} index The index in the array to decode from
- * @returns {{ tile: PlayerTile, nextIndex: number }}
+ * @returns {{ tile: Omit<PlayerTile, "conveyorDirection">, nextIndex: number }}
  */
 function decodePlayerTile(chars, index) {
   const status = chars[index + 1];
 
-  /** @type {PlayerTile} */
+  /** @type {Omit<PlayerTile, "conveyorDirection">} */
   let tile;
   switch (status) {
     case "a":
@@ -224,12 +319,12 @@ function encodeRockTile(tile) {
  *
  * @param {string[]} chars
  * @param {number} index The index in the array to decode from
- * @returns {{ tile: RockTile, nextIndex: number }}
+ * @returns {{ tile: Omit<RockTile, "conveyorDirection">, nextIndex: number }}
  */
 function decodeRockTile(chars, index) {
   const fallingDirection = chars[index + 1];
 
-  /** @type {RockTile} */
+  /** @type {Omit<RockTile, "conveyorDirection">} */
   let tile;
   switch (fallingDirection) {
     case "v":
@@ -295,12 +390,12 @@ function encodeWaterTile(tile) {
  *
  * @param {string[]} chars
  * @param {number} index The index in the array to decode from
- * @returns {{ tile: WaterTile, nextIndex: number }}
+ * @returns {{ tile: Omit<WaterTile, "conveyorDirection">, nextIndex: number }}
  */
 function decodeWaterTile(chars, index) {
   const flowDirection = chars[index + 1];
 
-  /** @type {WaterTile} */
+  /** @type {Omit<WaterTile, "conveyorDirection">} */
   let tile;
   switch (flowDirection) {
     case "+":
@@ -339,24 +434,32 @@ function decodeWaterTile(chars, index) {
  * @returns {string}
  */
 export function encodeTile(tile) {
+  let encoded;
   switch (tile.type) {
     case "Collectable":
     case "Empty":
     case "Wall":
-      return encodeGenericTile(tile);
+      encoded = encodeGenericTile(tile);
+      break;
 
     case "Dirt":
-      return encodeDirtTile(tile);
+      encoded = encodeDirtTile(tile);
+      break;
 
     case "Player":
-      return encodePlayerTile(tile);
+      encoded = encodePlayerTile(tile);
+      break;
 
     case "Rock":
-      return encodeRockTile(tile);
+      encoded = encodeRockTile(tile);
+      break;
 
     case "Water":
-      return encodeWaterTile(tile);
+      encoded = encodeWaterTile(tile);
+      break;
   }
+
+  return appendConveyorDirection(tile.conveyorDirection, encoded);
 }
 
 /**
@@ -367,24 +470,38 @@ export function encodeTile(tile) {
  * @returns {{ tile: Tile, nextIndex: number }}
  */
 export function decodeTile(chars, index) {
+  /** @type {{ tile: Omit<Tile, "conveyorDirection">, nextIndex: number }} */
+  let partialDecode;
   switch (chars[index]) {
     case "C":
     case "W":
     case " ":
-      return decodeGenericTile(chars, index);
+      partialDecode = decodeGenericTile(chars, index);
+      break;
 
     case "D":
-      return decodeDirtTile(chars, index);
+      partialDecode = decodeDirtTile(chars, index);
+      break;
 
     case "P":
-      return decodePlayerTile(chars, index);
+      partialDecode = decodePlayerTile(chars, index);
+      break;
 
     case "R":
-      return decodeRockTile(chars, index);
+      partialDecode = decodeRockTile(chars, index);
+      break;
 
     case "~":
-      return decodeWaterTile(chars, index);
+      partialDecode = decodeWaterTile(chars, index);
+      break;
+
+    default:
+      throw new Error(`Unexpected tile ${chars[index]} at ${index}`);
   }
 
-  throw new Error(`Unexpected tile ${chars[index]} at ${index}`);
+  return decodeConveyorDirection(
+    partialDecode.tile,
+    chars,
+    partialDecode.nextIndex
+  );
 }

--- a/test/board.spec.js
+++ b/test/board.spec.js
@@ -143,6 +143,34 @@ const successCases = [
     ),
     "2;2;1 1W2 ",
   ],
+  [
+    new Board(
+      2,
+      2,
+      [
+        { type: "Empty", conveyorDirection: "Right", justUpdated: false },
+        {
+          type: "Rock",
+          fallingDirection: "None",
+          conveyorDirection: "None",
+          justUpdated: false,
+        },
+        {
+          type: "Rock",
+          fallingDirection: "None",
+          conveyorDirection: "Down",
+          justUpdated: false,
+        },
+        {
+          type: "Rock",
+          fallingDirection: "Down",
+          conveyorDirection: "Down",
+          justUpdated: false,
+        },
+      ]
+    ),
+    "2;2;1 >1R.1R.v1Rvv",
+  ],
   [new Board(12, 24), "12;24;288 "],
 ];
 
@@ -173,6 +201,7 @@ describe("decodeBoard", function () {
     ["1;1;2 ", "Size does not match number of tiles"],
     ["1;1;1;", "Unexpected tile ; at 5"],
     ["1;1;1", "Unexpected tile undefined at 5"],
+    ["1;1;1 .", "Expected number at 6"],
   ];
 
   failureCases.forEach(([invalid, message]) => {

--- a/test/state.spec.js
+++ b/test/state.spec.js
@@ -1160,4 +1160,480 @@ describe("applyPatternTileUpdates", function () {
 
     stabilizeState(state, intermediateBoards);
   });
+
+  it("conveys living players down", function () {
+    const board = [
+      ["Pav"],
+      [" "],
+      [" "],
+    ];
+    const state = new State(arrayToBoard(board));
+
+    const intermediateBoards = [
+      [
+        [" v"],
+        ["Pa"],
+        [" "],
+      ],
+    ];
+
+    stabilizeState(state, intermediateBoards);
+  });
+
+  it("conveys dead players down", function () {
+    const board = [
+      ["Pdv"],
+      [" "],
+      [" "],
+    ];
+    const state = new State(arrayToBoard(board));
+
+    const intermediateBoards = [
+      [
+        [" v"],
+        ["Pd"],
+        [" "],
+      ],
+    ];
+
+    stabilizeState(state, intermediateBoards);
+  });
+
+  it("down-conveyed die by crashing into players", function () {
+    const board = [
+      ["Pav"],
+      ["Pd"],
+      [" "],
+    ];
+    const state = new State(arrayToBoard(board));
+
+    const intermediateBoards = [
+      [
+        ["Pdv"],
+        ["Pd"],
+        [" "],
+      ],
+    ];
+
+    stabilizeState(state, intermediateBoards);
+  });
+
+  it("down-conveyed players kill living players", function () {
+    const board = [
+      ["Pav"],
+      ["Pa"],
+      [" "],
+    ];
+    const state = new State(arrayToBoard(board));
+
+    const intermediateBoards = [
+      [
+        ["Pdv"],
+        ["Pd"],
+        [" "],
+      ],
+    ];
+
+    stabilizeState(state, intermediateBoards);
+  });
+
+  it("conveys living players left", function () {
+    const board = [
+      [" ", " ", "Pa<"],
+    ];
+    const state = new State(arrayToBoard(board));
+
+    const intermediateBoards = [
+      [
+        [" ", "Pa", " <"],
+      ],
+    ];
+
+    stabilizeState(state, intermediateBoards);
+  });
+
+  it("conveys dead players left", function () {
+    const board = [
+      [" ", " ", "Pd<"],
+    ];
+    const state = new State(arrayToBoard(board));
+
+    const intermediateBoards = [
+      [
+        [" ", "Pd", " <"],
+      ],
+    ];
+
+    stabilizeState(state, intermediateBoards);
+  });
+
+  it("left-conveyed die by crashing into players", function () {
+    const board = [
+      [" ", "Pd", "Pa<"],
+    ];
+    const state = new State(arrayToBoard(board));
+
+    const intermediateBoards = [
+      [
+        [" ", "Pd", "Pd<"],
+      ],
+    ];
+
+    stabilizeState(state, intermediateBoards);
+  });
+
+  it("left-conveyed players kill living players", function () {
+    const board = [
+      [" ", "Pa", "Pa<"],
+    ];
+    const state = new State(arrayToBoard(board));
+
+    const intermediateBoards = [
+      [
+        [" ", "Pd", "Pd<"],
+      ],
+    ];
+
+    stabilizeState(state, intermediateBoards);
+  });
+
+  it("left-conveyed living players push single rocks", function () {
+    const board = [
+      [" ", " ", "R.", "Pa<"],
+    ];
+    const state = new State(arrayToBoard(board));
+
+    const intermediateBoards = [
+      [
+        [" ", "R.", "Pa", " <"],
+      ],
+    ];
+
+    stabilizeState(state, intermediateBoards);
+  });
+
+  it("left-conveyed dead players push single rocks", function () {
+    const board = [
+      [" ", " ", "R.", "Pd<"],
+    ];
+    const state = new State(arrayToBoard(board));
+
+    const intermediateBoards = [
+      [
+        [" ", "R.", "Pd", " <"],
+      ],
+    ];
+
+    stabilizeState(state, intermediateBoards);
+  });
+
+  it("left-conveyed players crash into double rocks rocks", function () {
+    const board = [
+      [" ", "R.", "R.", "Pa<"],
+    ];
+    const state = new State(arrayToBoard(board));
+
+    const intermediateBoards = [
+      [
+        [" ", "R.", "R.", "Pd<"],
+      ],
+    ];
+
+    stabilizeState(state, intermediateBoards);
+  });
+
+  it("left-conveyed rocks kill players", function () {
+    const board = [
+      [" ", "Pa", "R.", "Pa<"],
+    ];
+    const state = new State(arrayToBoard(board));
+
+    const intermediateBoards = [
+      [
+        [" ", "Pd", "R.", "Pd<"],
+      ],
+    ];
+
+    stabilizeState(state, intermediateBoards);
+  });
+
+  it("conveys living players right", function () {
+    const board = [
+      ["Pa>", " ", " "],
+    ];
+    const state = new State(arrayToBoard(board));
+
+    const intermediateBoards = [
+      [
+        [" >", "Pa", " "],
+      ],
+    ];
+
+    stabilizeState(state, intermediateBoards);
+  });
+
+  it("conveys dead players right", function () {
+    const board = [
+      ["Pd>", " ", " "],
+    ];
+    const state = new State(arrayToBoard(board));
+
+    const intermediateBoards = [
+      [
+        [" >", "Pd", " "],
+      ],
+    ];
+
+    stabilizeState(state, intermediateBoards);
+  });
+
+  it("right-conveyed die by crashing into players", function () {
+    const board = [
+      ["Pa>", "Pd", " "],
+    ];
+    const state = new State(arrayToBoard(board));
+
+    const intermediateBoards = [
+      [
+        ["Pd>", "Pd", " "],
+      ],
+    ];
+
+    stabilizeState(state, intermediateBoards);
+  });
+
+  it("right-conveyed players kill living players", function () {
+    const board = [
+      ["Pa>", "Pa", " "],
+    ];
+    const state = new State(arrayToBoard(board));
+
+    const intermediateBoards = [
+      [
+        ["Pd>", "Pd", " "],
+      ],
+    ];
+
+    stabilizeState(state, intermediateBoards);
+  });
+
+  it("right-conveyed living players push single rocks", function () {
+    const board = [
+      ["Pa>", "R.", " ", " "],
+    ];
+    const state = new State(arrayToBoard(board));
+
+    const intermediateBoards = [
+      [
+        [" >", "Pa", "R.", " "],
+      ],
+    ];
+
+    stabilizeState(state, intermediateBoards);
+  });
+
+  it("right-conveyed dead players push single rocks", function () {
+    const board = [
+      ["Pd>", "R.", " ", " "],
+    ];
+    const state = new State(arrayToBoard(board));
+
+    const intermediateBoards = [
+      [
+        [" >", "Pd", "R.", " "],
+      ],
+    ];
+
+    stabilizeState(state, intermediateBoards);
+  });
+
+  it("right-conveyed players crash into double rocks rocks", function () {
+    const board = [
+      ["Pa>", "R.", "R.", " "],
+    ];
+    const state = new State(arrayToBoard(board));
+
+    const intermediateBoards = [
+      [
+        ["Pd>", "R.", "R.", " "],
+      ],
+    ];
+
+    stabilizeState(state, intermediateBoards);
+  });
+
+  it("right-conveyed rocks kill players", function () {
+    const board = [
+      ["Pa>", "R.", "Pa", " "],
+    ];
+    const state = new State(arrayToBoard(board));
+
+    const intermediateBoards = [
+      [
+        ["Pd>", "R.", "Pd", " "],
+      ],
+    ];
+
+    stabilizeState(state, intermediateBoards);
+  });
+
+  it("conveys living players up", function () {
+    const board = [
+      [" "],
+      [" "],
+      ["Pa^"],
+    ];
+    const state = new State(arrayToBoard(board));
+
+    const intermediateBoards = [
+      [
+        [" "],
+        ["Pa"],
+        [" ^"],
+      ],
+    ];
+
+    stabilizeState(state, intermediateBoards);
+  });
+
+  it("conveys dead players up", function () {
+    const board = [
+      [" "],
+      [" "],
+      ["Pd^"],
+    ];
+    const state = new State(arrayToBoard(board));
+
+    const intermediateBoards = [
+      [
+        [" "],
+        ["Pd"],
+        [" ^"],
+      ],
+    ];
+
+    stabilizeState(state, intermediateBoards);
+  });
+
+  it("up-conveyed die by crashing into players", function () {
+    const board = [
+      [" "],
+      ["Pd"],
+      ["Pa^"],
+    ];
+    const state = new State(arrayToBoard(board));
+
+    const intermediateBoards = [
+      [
+        [" "],
+        ["Pd"],
+        ["Pd^"],
+      ],
+    ];
+
+    stabilizeState(state, intermediateBoards);
+  });
+
+  it("up-conveyed players kill living players", function () {
+    const board = [
+      [" "],
+      ["Pa"],
+      ["Pa^"],
+    ];
+    const state = new State(arrayToBoard(board));
+
+    const intermediateBoards = [
+      [
+        [" "],
+        ["Pd"],
+        ["Pd^"],
+      ],
+    ];
+
+    stabilizeState(state, intermediateBoards);
+  });
+
+  it("up-conveyed living players push single rocks", function () {
+    const board = [
+      [" "],
+      [" "],
+      ["R."],
+      ["Pa^"],
+    ];
+    const state = new State(arrayToBoard(board));
+
+    const intermediateBoards = [
+      [
+        [" "],
+        ["R."],
+        ["Pa"],
+        [" ^"],
+      ],
+    ];
+
+    stabilizeState(state, intermediateBoards);
+  });
+
+  it("up-conveyed dead players push single rocks", function () {
+    const board = [
+      [" "],
+      [" "],
+      ["R."],
+      ["Pd^"],
+    ];
+    const state = new State(arrayToBoard(board));
+
+    const intermediateBoards = [
+      [
+        [" "],
+        ["R."],
+        ["Pd"],
+        [" ^"],
+      ],
+    ];
+
+    stabilizeState(state, intermediateBoards);
+  });
+
+  it("up-conveyed players crash into double rocks rocks", function () {
+    const board = [
+      [" "],
+      ["R."],
+      ["R."],
+      ["Pa^"],
+    ];
+    const state = new State(arrayToBoard(board));
+
+    const intermediateBoards = [
+      [
+        [" "],
+        ["R."],
+        ["R."],
+        ["Pd^"],
+      ],
+    ];
+
+    stabilizeState(state, intermediateBoards);
+  });
+
+  it("up-conveyed rocks kill players", function () {
+    const board = [
+      [" "],
+      ["Pa"],
+      ["R."],
+      ["Pa^"],
+    ];
+    const state = new State(arrayToBoard(board));
+
+    const intermediateBoards = [
+      [
+        [" "],
+        ["Pd"],
+        ["R."],
+        ["Pd^"],
+      ],
+    ];
+
+    stabilizeState(state, intermediateBoards);
+  });
 });

--- a/test/tile.spec.js
+++ b/test/tile.spec.js
@@ -9,25 +9,169 @@ import { decodeTile, encodeTile } from "../src/tile.js"
 
 /** @type {[Tile, string][]} */
 const successCases = [
-  [{ type: "Collectable", justUpdated: false }, "C"],
-  [{ type: "Empty", justUpdated: false }, " "],
-  [{ type: "Wall", justUpdated: false }, "W"],
-  [{ type: "Dirt", flowDirection: "Both", justUpdated: false }, "D_"],
-  [{ type: "Dirt", flowDirection: "Down", justUpdated: false }, "Dv"],
-  [{ type: "Dirt", flowDirection: "Left", justUpdated: false }, "D<"],
-  [{ type: "Dirt", flowDirection: "None", justUpdated: false }, "D."],
-  [{ type: "Dirt", flowDirection: "Right", justUpdated: false }, "D>"],
-  [{ type: "Player", isAlive: true, justUpdated: false }, "Pa"],
-  [{ type: "Player", isAlive: false, justUpdated: false }, "Pd"],
-  [{ type: "Rock", fallingDirection: "Down", justUpdated: false }, "Rv"],
-  [{ type: "Rock", fallingDirection: "DownLeft", justUpdated: false }, "R<"],
-  [{ type: "Rock", fallingDirection: "DownRight", justUpdated: false }, "R>"],
-  [{ type: "Rock", fallingDirection: "None", justUpdated: false }, "R."],
-  [{ type: "Water", flowDirection: "All", justUpdated: false }, "~+"],
-  [{ type: "Water", flowDirection: "Both", justUpdated: false }, "~_"],
-  [{ type: "Water", flowDirection: "Down", justUpdated: false }, "~v"],
-  [{ type: "Water", flowDirection: "Left", justUpdated: false }, "~<"],
-  [{ type: "Water", flowDirection: "Right", justUpdated: false }, "~>"],
+  [
+    { type: "Collectable", conveyorDirection: "None", justUpdated: false },
+    "C",
+  ],
+  [{ type: "Empty", conveyorDirection: "None", justUpdated: false }, " "],
+  [{ type: "Empty", conveyorDirection: "Down", justUpdated: false }, " v"],
+  [{ type: "Empty", conveyorDirection: "Left", justUpdated: false }, " <"],
+  [{ type: "Empty", conveyorDirection: "Right", justUpdated: false }, " >"],
+  [{ type: "Empty", conveyorDirection: "Up", justUpdated: false }, " ^"],
+  [{ type: "Wall", conveyorDirection: "None", justUpdated: false }, "W"],
+  [
+    {
+      type: "Dirt",
+      conveyorDirection: "None",
+      flowDirection: "Both",
+      justUpdated: false,
+    },
+    "D_",
+  ],
+  [
+    {
+      type: "Dirt",
+      conveyorDirection: "None",
+      flowDirection: "Down",
+      justUpdated: false,
+    },
+    "Dv",
+  ],
+  [
+    {
+      type: "Dirt",
+      conveyorDirection: "None",
+      flowDirection: "Left",
+      justUpdated: false,
+    },
+    "D<",
+  ],
+  [
+    {
+      type: "Dirt",
+      conveyorDirection: "None",
+      flowDirection: "None",
+      justUpdated: false,
+    },
+    "D.",
+  ],
+  [
+    {
+      type: "Dirt",
+      conveyorDirection: "Down",
+      flowDirection: "None",
+      justUpdated: false,
+    },
+    "D.v",
+  ],
+  [
+    {
+      type: "Dirt",
+      conveyorDirection: "None",
+      flowDirection: "Right",
+      justUpdated: false,
+    },
+    "D>",
+  ],
+  [
+    {
+      type: "Player",
+      conveyorDirection: "None",
+      isAlive: true,
+      justUpdated: false,
+    },
+    "Pa",
+  ],
+  [
+    {
+      type: "Player",
+      conveyorDirection: "None",
+      isAlive: false,
+      justUpdated: false,
+    },
+    "Pd",
+  ],
+  [
+    {
+      type: "Rock",
+      conveyorDirection: "None",
+      fallingDirection: "Down",
+      justUpdated: false,
+    },
+    "Rv",
+  ],
+  [
+    {
+      type: "Rock",
+      conveyorDirection: "None",
+      fallingDirection: "DownLeft",
+      justUpdated: false,
+    },
+    "R<",
+  ],
+  [
+    {
+      type: "Rock",
+      conveyorDirection: "None",
+      fallingDirection: "DownRight",
+      justUpdated: false,
+    },
+    "R>",
+  ],
+  [
+    {
+      type: "Rock",
+      conveyorDirection: "None",
+      fallingDirection: "None",
+      justUpdated: false,
+    },
+    "R.",
+  ],
+  [
+    {
+      type: "Water",
+      conveyorDirection: "None",
+      flowDirection: "All",
+      justUpdated: false,
+    },
+    "~+",
+  ],
+  [
+    {
+      type: "Water",
+      conveyorDirection: "None",
+      flowDirection: "Both",
+      justUpdated: false,
+    },
+    "~_",
+  ],
+  [
+    {
+      type: "Water",
+      conveyorDirection: "None",
+      flowDirection: "Down",
+      justUpdated: false,
+    },
+    "~v",
+  ],
+  [
+    {
+      type: "Water",
+      conveyorDirection: "None",
+      flowDirection: "Left",
+      justUpdated: false,
+    },
+    "~<",
+  ],
+  [
+    {
+      type: "Water",
+      conveyorDirection: "None",
+      flowDirection: "Right",
+      justUpdated: false,
+    },
+    "~>",
+  ],
 ];
 
 describe("encodeTile", function () {


### PR DESCRIPTION
This change adds conveyors as a map element. Each tile now has an additional property specifying which direction, if any, a player will automatically move if placed on that tile. Conveyors move the player in any of the cardinal directions.

Only players are moved by conveyors but a player on a conveyor can also move a rock as if the player were moving on their own.

If a conveyor cannot move a player because there is an obstacle in the way then the player dies.

If an object is moved into a player, the player also dies.