### PR TITLE
fix: #7 Falling rocks don't always resolve to no falling direction

### DIFF
--- a/src/patterns.js
+++ b/src/patterns.js
@@ -607,58 +607,6 @@ export const patterns = [
       null, { type: "Player", isAlive: false }, null,
     ],
   ],
-  // Rocks wait for other falling rocks to fall left off a rock below them
-  [
-    [
-      any, any, any,
-      isFallingRock, isFallingRock, any,
-      or(isEmptyForRock, isFallingRock), isTile({ type: "Rock" }), any,
-    ],
-    [
-      null, null, null,
-      null, { type: "Rock", fallingDirection: "DownLeft" }, null,
-      null, null, null,
-    ],
-  ],
-  // Rocks wait for other falling rocks to fall left off a rock below them
-  [
-    [
-      any, any, any,
-      any, isFallingRock, any,
-      isFallingRock, isTile({ type: "Rock" }), any,
-    ],
-    [
-      null, null, null,
-      null, { type: "Rock", fallingDirection: "DownLeft" }, null,
-      null, null, null,
-    ],
-  ],
-  // Rocks wait for other falling rocks to fall right off a rock below them
-  [
-    [
-      any, any, any,
-      not(isEmptyForRock), isFallingRock, isFallingRock,
-      any, isTile({ type: "Rock" }), or(isEmptyForRock, isFallingRock),
-    ],
-    [
-      null, null, null,
-      null, { type: "Rock", fallingDirection: "DownRight" }, null,
-      null, null, null,
-    ],
-  ],
-  // Rocks wait for other falling rocks to fall right off a rock below them
-  [
-    [
-      any, any, any,
-      not(isEmptyForRock), isFallingRock, any,
-      any, isTile({ type: "Rock" }), isFallingRock,
-    ],
-    [
-      null, null, null,
-      null, { type: "Rock", fallingDirection: "DownRight" }, null,
-      null, null, null,
-    ],
-  ],
   // Rocks fall left off a hard surface
   [
     [
@@ -716,7 +664,7 @@ export const patterns = [
     [
       any, any, any,
       any, isFallingRock, any,
-      not(isEmptyForRock), not(isEmptyForRock), not(isEmptyForRock),
+      any, any, any,
     ],
     [
       null, null, null,

--- a/test/state.spec.js
+++ b/test/state.spec.js
@@ -204,7 +204,7 @@ describe("applyPatternTileUpdates", function () {
     stabilizeState(state, intermediateBoards);
   });
 
-  it("ensures rocks falling to the left don't overlap rocks falling down", function () {
+  it("ensures falling rocks stop falling rocks from rolling right", function () {
     const board = [
       ["R.", "R."],
       [" ", " "],
@@ -222,20 +222,20 @@ describe("applyPatternTileUpdates", function () {
       ],
       [
         [" ", " "],
-        ["R>", " "],
+        ["R.", " "],
         ["R.", "Rv"],
         ["W", " "],
       ],
       [
         [" ", " "],
-        [" ", " "],
-        ["R.", "R>"],
+        ["R.", " "],
+        ["R.", " "],
         ["W", "Rv"],
       ],
       [
         [" ", " "],
-        [" ", " "],
-        ["R.", "R."],
+        ["R.", " "],
+        ["R.", " "],
         ["W", "R."],
       ],
     ];
@@ -243,7 +243,7 @@ describe("applyPatternTileUpdates", function () {
     stabilizeState(state, intermediateBoards);
   });
 
-  it("ensures rocks falling to the right don't overlap rocks falling down", function () {
+  it("ensures falling rocks stop falling rocks from rolling left", function () {
     const board = [
       ["R.", "R."],
       [" ", " "],
@@ -261,20 +261,20 @@ describe("applyPatternTileUpdates", function () {
       ],
       [
         [" ", " "],
-        [" ", "R<"],
+        [" ", "R."],
         ["Rv", "R."],
         [" ", "W"],
       ],
       [
         [" ", " "],
-        [" ", " "],
-        ["R<", "R."],
+        [" ", "R."],
+        [" ", "R."],
         ["Rv", "W"],
       ],
       [
         [" ", " "],
-        [" ", " "],
-        ["R.", "R."],
+        [" ", "R."],
+        [" ", "R."],
         ["R.", "W"],
       ],
     ];
@@ -302,30 +302,30 @@ describe("applyPatternTileUpdates", function () {
       ],
       [
         [" ", " ", " "],
-        ["R>", " ", " "],
+        ["R.", " ", " "],
         ["R.", "R<", "R."],
         ["W", " ", "W"],
         [" ", " ", " "],
       ],
       [
         [" ", " ", " "],
-        [" ", " ", " "],
-        ["R.", "R>", "R."],
+        ["R.", " ", " "],
+        ["R.", " ", "R."],
         ["W", "Rv", "W"],
         [" ", " ", " "],
       ],
       [
         [" ", " ", " "],
-        [" ", " ", " "],
+        ["R.", " ", " "],
         ["R.", " ", "R."],
-        ["W", "Rv", "W"],
+        ["W", " ", "W"],
         [" ", "Rv", " "],
       ],
       [
         [" ", " ", " "],
-        [" ", " ", " "],
+        ["R.", " ", " "],
         ["R.", " ", "R."],
-        ["W", "Rv", "W"],
+        ["W", " ", "W"],
         [" ", "R.", " "],
       ],
     ];
@@ -372,108 +372,6 @@ describe("applyPatternTileUpdates", function () {
     stabilizeState(state, intermediateBoards);
   });
 
-  it("ensures rocks cascading to the left don't block other rocks cascading to the left", function () {
-    const board = [
-      ["R.", "R.", " "],
-      [" ", " ", " "],
-      ["R.", " ", " "],
-      ["W", "R.", " "],
-      [" ", "W", " "],
-    ];
-    const state = new State(arrayToBoard(board));
-
-    const intermediateBoards = [
-      [
-        [" ", " ", " "],
-        ["Rv", "Rv", " "],
-        ["R.", " ", " "],
-        ["W", "R.", " "],
-        [" ", "W", " "],
-      ],
-      [
-        [" ", " ", " "],
-        ["R>", " ", " "],
-        ["R.", "Rv", " "],
-        ["W", "R.", " "],
-        [" ", "W", " "],
-      ],
-      [
-        [" ", " ", " "],
-        [" ", " ", " "],
-        ["R.", "R>", " "],
-        ["W", "R.", "R>"],
-        [" ", "W", " "],
-      ],
-      [
-        [" ", " ", " "],
-        [" ", " ", " "],
-        ["R.", " ", " "],
-        ["W", "R.", "R>"],
-        [" ", "W", "Rv"],
-      ],
-      [
-        [" ", " ", " "],
-        [" ", " ", " "],
-        ["R.", " ", " "],
-        ["W", "R.", "R."],
-        [" ", "W", "R."],
-      ],
-    ];
-
-    stabilizeState(state, intermediateBoards);
-  });
-
-  it("ensures rocks cascading to the right don't block other rocks cascading to the right", function () {
-    const board = [
-      [" ", "R.", "R."],
-      [" ", " ", " "],
-      [" ", " ", "R."],
-      [" ", "R.", "W"],
-      [" ", "W", " "],
-    ];
-    const state = new State(arrayToBoard(board));
-
-    const intermediateBoards = [
-      [
-        [" ", " ", " "],
-        [" ", "Rv", "Rv"],
-        [" ", " ", "R."],
-        [" ", "R.", "W"],
-        [" ", "W", " "],
-      ],
-      [
-        [" ", " ", " "],
-        [" ", " ", "R<"],
-        [" ", "Rv", "R."],
-        [" ", "R.", "W"],
-        [" ", "W", " "],
-      ],
-      [
-        [" ", " ", " "],
-        [" ", " ", " "],
-        [" ", "R<", "R."],
-        ["R<", "R.", "W"],
-        [" ", "W", " "],
-      ],
-      [
-        [" ", " ", " "],
-        [" ", " ", " "],
-        [" ", " ", "R."],
-        ["R<", "R.", "W"],
-        ["Rv", "W", " "],
-      ],
-      [
-        [" ", " ", " "],
-        [" ", " ", " "],
-        [" ", " ", "R."],
-        ["R.", "R.", "W"],
-        ["R.", "W", " "],
-      ],
-    ];
-
-    stabilizeState(state, intermediateBoards);
-  });
-
   it("ensures rocks always fall when nothing is below them", function () {
     const board = [
       [" ", " ", "R.", " "],
@@ -502,7 +400,7 @@ describe("applyPatternTileUpdates", function () {
         [" ", " ", " ", " "],
         [" ", " ", " ", " "],
         [" ", " ", "Rv", " "],
-        ["Rv", "R<", "Rv", "Rv"],
+        ["Rv", "R<", "R.", "Rv"],
         ["Rv", "Rv", "W", "Rv"],
         [" ", " ", " ", " "],
         ["W", " ", " ", " "],
@@ -512,7 +410,7 @@ describe("applyPatternTileUpdates", function () {
         [" ", " ", " ", " "],
         [" ", " ", " ", " "],
         [" ", " ", " ", " "],
-        [" ", "R<", "Rv", " "],
+        [" ", "R<", "R.", " "],
         ["Rv", "Rv", "W", "Rv"],
         ["Rv", "Rv", " ", "Rv"],
         ["W", " ", " ", " "],
@@ -522,8 +420,8 @@ describe("applyPatternTileUpdates", function () {
         [" ", " ", " ", " "],
         [" ", " ", " ", " "],
         [" ", " ", " ", " "],
-        [" ", " ", " ", " "],
-        ["R>", "Rv", "W", "R>"],
+        [" ", " ", "R.", " "],
+        ["R.", "Rv", "W", " "],
         ["R.", "Rv", " ", "Rv"],
         ["W", "Rv", " ", "Rv"],
         [" ", " ", " ", " "],
@@ -532,9 +430,9 @@ describe("applyPatternTileUpdates", function () {
         [" ", " ", " ", " "],
         [" ", " ", " ", " "],
         [" ", " ", " ", " "],
-        [" ", " ", " ", " "],
-        ["R>", " ", "W", " "],
-        ["R.", "Rv", " ", "Rv"],
+        [" ", " ", "R.", " "],
+        ["R.", " ", "W", " "],
+        ["R.", "Rv", " ", " "],
         ["W", "Rv", " ", "Rv"],
         [" ", "Rv", " ", "Rv"],
       ],
@@ -542,20 +440,20 @@ describe("applyPatternTileUpdates", function () {
         [" ", " ", " ", " "],
         [" ", " ", " ", " "],
         [" ", " ", " ", " "],
-        [" ", " ", " ", " "],
-        [" ", " ", "W", " "],
-        ["R.", "R>", " ", " "],
-        ["W", "R>", "R>", "Rv"],
+        [" ", " ", "R.", " "],
+        ["R.", " ", "W", " "],
+        ["R.", " ", " ", " "],
+        ["W", "R.", "R>", " "],
         [" ", "R.", "R<", "R."],
       ],
       [
         [" ", " ", " ", " "],
         [" ", " ", " ", " "],
         [" ", " ", " ", " "],
-        [" ", " ", " ", " "],
-        [" ", " ", "W", " "],
-        ["R.", "R.", " ", " "],
-        ["W", "R>", "R.", "R."],
+        [" ", " ", "R.", " "],
+        ["R.", " ", "W", " "],
+        ["R.", " ", " ", " "],
+        ["W", "R.", "R.", " "],
         [" ", "R.", "R.", "R."],
       ],
     ];


### PR DESCRIPTION
Currently rocks that would cascade wait for any rocks that are falling on the side they would cascade to. This creates a difficult to predict situation where a rock can wait an arbitrary amount of time before cascading while also allowing for a case when rocks never resolve their fall.

This change simplifies how rocks fall so that rocks only cascade when there is nothing blocking their path. If something is blocking their path then they immediately stop falling.