### PR TITLE
Falling rocks kill up-conveyed players

### DIFF
--- a/src/patterns.js
+++ b/src/patterns.js
@@ -516,6 +516,19 @@ export const patterns = [
       null, null, null,
     ],
   ],
+  // Falling rocks kill up-conveyed players
+  [
+    [
+      any, isEmptyForRock, any,
+      any, isFallingRock, any,
+      any, and(isLivingPlayer, isConveyoredPlayer("Up")), any,
+    ],
+    [
+      null, { type: "Rock", fallingDirection: "None" }, null,
+      null, { type: "Player", isAlive: false }, null,
+      null, { type: "Empty" }, null,
+    ],
+  ],
   // Up conveyored living players move rocks
   [
     [

--- a/test/state.spec.js
+++ b/test/state.spec.js
@@ -1534,4 +1534,31 @@ describe("applyPatternTileUpdates", function () {
 
     stabilizeState(state, intermediateBoards);
   });
+
+  it("falling rocks kill up-conveyed players", function () {
+    const board = [
+      ["R."],
+      [" ^"],
+      [" ^"],
+      ["Pa^"],
+    ];
+    const state = new State(arrayToBoard(board));
+
+    const intermediateBoards = [
+      [
+        [" "],
+        ["Rv^"],
+        ["Pa^"],
+        [" ^"],
+      ],
+      [
+        ["R."],
+        ["Pd^"],
+        [" ^"],
+        [" ^"],
+      ],
+    ];
+
+    stabilizeState(state, intermediateBoards);
+  });
 });


### PR DESCRIPTION
Fixes #17 - falling rocks should kill up-conveyed players rather than those players pushing those rocks. This is equivalent to a player crashing into a rock otherwise and so should kill them.