### PR TITLE
Handle player movement with the state machine

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
   </body>
   <script type="module">
     import { Board, decodeBoard, encodeBoard } from "./src/board.js";
-    import { State, movePlayer } from "./src/state.js";
+    import { State } from "./src/state.js";
 
     const tickMs = 250;
     const tileSize = 20;
@@ -231,6 +231,7 @@
           return {
             type,
             isAlive: true,
+            inputDirection: "None",
             justUpdated: false,
             conveyorDirection,
           };
@@ -325,25 +326,25 @@
         case "Up":
         case "ArrowUp":
         case "w":
-          updatedPoints.push(...movePlayer(state, "Up"));
+          updatedPoints.push(...state.movePlayers("Up"));
           break;
 
         case "Left":
         case "ArrowLeft":
         case "a":
-          updatedPoints.push(...movePlayer(state, "Left"));
+          updatedPoints.push(...state.movePlayers("Left"));
           break;
 
         case "Down":
         case "ArrowDown":
         case "s":
-          updatedPoints.push(...movePlayer(state, "Down"));
+          updatedPoints.push(...state.movePlayers("Down"));
           break;
 
         case "Right":
         case "ArrowRight":
         case "d":
-          updatedPoints.push(...movePlayer(state, "Right"));
+          updatedPoints.push(...state.movePlayers("Right"));
           break;
 
         default:
@@ -355,6 +356,8 @@
         renderBoard(boardElement, state.board, updatedPoints);
         renderGameState(state);
         keyboardEvent.preventDefault(); // Prevent other browser behaviors
+
+        startGameClock();
       }
     }
 
@@ -376,7 +379,29 @@
       }
     }
 
-    let timerId;
+    let timerId = undefined;
+    function startGameClock() {
+      if (!timerId) {
+        timerId = setInterval(
+          () => {
+            if (state.updatedTiles.length > 0) {
+              const updatedPoints = state.applyUpdates();
+              renderBoard(boardElement, state.board, updatedPoints);
+              renderGameState(state);
+            } else {
+              stopGameClock();
+            }
+          },
+          tickMs
+        );
+      }
+    }
+
+    function stopGameClock() {
+      clearInterval(timerId);
+      timerId = undefined;
+    }
+
     buildButton.addEventListener("click", () => {
       buildButton.disabled = true;
       playButton.disabled = false;
@@ -391,13 +416,14 @@
       boardElement.addEventListener("mousemove", updateDraggedTiles);
       boardElement.addEventListener("click", updateTile);
 
-      clearInterval(timerId);
+      stopGameClock();
 
       renderBoard(boardElement, board);
     });
 
     resetButton.addEventListener("click", () => {
       state.reset();
+      startGameClock();
       renderBoard(boardElement, board);
       renderGameState(state);
     });
@@ -411,7 +437,6 @@
       playButton.blur(); // Returns focus to the document
 
       state = new State(board.clone());
-      state.updateEntireBoard();
       renderGameState(state);
 
       document.addEventListener("keydown", handleInput);
@@ -421,16 +446,7 @@
       boardElement.removeEventListener("mousemove", updateDraggedTiles);
       boardElement.removeEventListener("click", updateTile);
 
-      timerId = setInterval(
-        () => {
-          if (state.updatedTiles.length > 0) {
-            const updatedPoints = state.applyUpdates();
-            renderBoard(boardElement, state.board, updatedPoints);
-            renderGameState(state);
-          }
-        },
-        tickMs
-      );
+      startGameClock();
 
       renderBoard(boardElement, board);
     });

--- a/test/state.spec.js
+++ b/test/state.spec.js
@@ -46,8 +46,6 @@ function stabilizeState(state, intermediateBoards) {
   const originalBoard = boardToArray(state.board);
 
   let currentIndex = 0;
-  state.updateEntireBoard();
-
   while (state.updatedTiles.length > 0) {
     state.applyUpdates();
 
@@ -464,7 +462,7 @@ describe("applyPatternTileUpdates", function () {
   it("allows rocks to rest on a player", function () {
     const board = [
       ["R."],
-      ["Pa"],
+      ["Pa."],
       [" "],
     ];
     const state = new State(arrayToBoard(board));
@@ -479,7 +477,7 @@ describe("applyPatternTileUpdates", function () {
     const board = [
       ["R."],
       [" "],
-      ["Pa"],
+      ["Pa."],
     ];
     const state = new State(arrayToBoard(board));
 
@@ -488,7 +486,7 @@ describe("applyPatternTileUpdates", function () {
       [
         [" "],
         ["Rv"],
-        ["Pa"],
+        ["Pa."],
       ],
       [
         [" "],
@@ -504,7 +502,7 @@ describe("applyPatternTileUpdates", function () {
     const board = [
       [" ", "R."],
       [" ", " "],
-      ["Pa", "W"],
+      ["Pa.", "W"],
     ];
     const state = new State(arrayToBoard(board));
 
@@ -513,7 +511,7 @@ describe("applyPatternTileUpdates", function () {
       [
         [" ", " "],
         [" ", "Rv"],
-        ["Pa", "W"],
+        ["Pa.", "W"],
       ],
       [
         [" ", " "],
@@ -529,7 +527,7 @@ describe("applyPatternTileUpdates", function () {
     const board = [
       ["R.", " "],
       [" ", " "],
-      ["W", "Pa"],
+      ["W", "Pa."],
     ];
     const state = new State(arrayToBoard(board));
 
@@ -538,7 +536,7 @@ describe("applyPatternTileUpdates", function () {
       [
         [" ", " "],
         ["Rv", " "],
-        ["W", "Pa"],
+        ["W", "Pa."],
       ],
       [
         [" ", " "],
@@ -584,7 +582,7 @@ describe("applyPatternTileUpdates", function () {
     const board = [
       ["~+"],
       [" "],
-      ["Pa"],
+      ["Pa."],
     ];
     const state = new State(arrayToBoard(board));
 
@@ -593,7 +591,7 @@ describe("applyPatternTileUpdates", function () {
       [
         ["~+"],
         ["~v"],
-        ["Pa"],
+        ["Pa."],
       ],
       [
         ["~+"],
@@ -631,14 +629,14 @@ describe("applyPatternTileUpdates", function () {
 
   it("ensures right-flowing water kills a player", function () {
     const board = [
-      ["~+", " ", "Pa"],
+      ["~+", " ", "Pa."],
     ];
     const state = new State(arrayToBoard(board));
 
     /** @type {TestBoard[]} */
     const intermediateBoards = [
       [
-        ["~+", "~>", "Pa"],
+        ["~+", "~>", "Pa."],
       ],
       [
         ["~+", "~>", "Pd"],
@@ -669,14 +667,14 @@ describe("applyPatternTileUpdates", function () {
 
   it("ensures left-flowing water kills a player", function () {
     const board = [
-      ["Pa", " ", "~+"],
+      ["Pa.", " ", "~+"],
     ];
     const state = new State(arrayToBoard(board));
 
     /** @type {TestBoard[]} */
     const intermediateBoards = [
       [
-        ["Pa", "~<", "~+"],
+        ["Pa.", "~<", "~+"],
       ],
       [
         ["Pd", "~<", "~+"],
@@ -835,7 +833,7 @@ describe("applyPatternTileUpdates", function () {
     const board = [
       ["~+"],
       ["D."],
-      ["Pa"],
+      ["Pa."],
     ];
     const state = new State(arrayToBoard(board));
 
@@ -844,7 +842,7 @@ describe("applyPatternTileUpdates", function () {
       [
         ["~+"],
         ["D_"],
-        ["Pa"],
+        ["Pa."],
       ],
       [
         ["~+"],
@@ -877,14 +875,14 @@ describe("applyPatternTileUpdates", function () {
 
   it("ensures right-flowing water kills a player", function () {
     const board = [
-      ["~+", "D.", "Pa"],
+      ["~+", "D.", "Pa."],
     ];
     const state = new State(arrayToBoard(board));
 
     /** @type {TestBoard[]} */
     const intermediateBoards = [
       [
-        ["~+", "D>", "Pa"],
+        ["~+", "D>", "Pa."],
       ],
       [
         ["~+", "D>", "Pd"],
@@ -915,14 +913,14 @@ describe("applyPatternTileUpdates", function () {
 
   it("ensures left-flowing water kills a player", function () {
     const board = [
-      ["Pa", "D.", "~+"],
+      ["Pa.", "D.", "~+"],
     ];
     const state = new State(arrayToBoard(board));
 
     /** @type {TestBoard[]} */
     const intermediateBoards = [
       [
-        ["Pa", "D<", "~+"],
+        ["Pa.", "D<", "~+"],
       ],
       [
         ["Pd", "D<", "~+"],
@@ -1061,7 +1059,7 @@ describe("applyPatternTileUpdates", function () {
 
   it("conveys living players down", function () {
     const board = [
-      ["Pav"],
+      ["Pa.v"],
       [" "],
       [" "],
     ];
@@ -1070,7 +1068,7 @@ describe("applyPatternTileUpdates", function () {
     const intermediateBoards = [
       [
         [" v"],
-        ["Pa"],
+        ["Pa."],
         [" "],
       ],
     ];
@@ -1099,7 +1097,7 @@ describe("applyPatternTileUpdates", function () {
 
   it("down-conveyed die by crashing into players", function () {
     const board = [
-      ["Pav"],
+      ["Pa.v"],
       ["Pd"],
       [" "],
     ];
@@ -1118,8 +1116,8 @@ describe("applyPatternTileUpdates", function () {
 
   it("down-conveyed players kill living players", function () {
     const board = [
-      ["Pav"],
-      ["Pa"],
+      ["Pa.v"],
+      ["Pa."],
       [" "],
     ];
     const state = new State(arrayToBoard(board));
@@ -1137,13 +1135,13 @@ describe("applyPatternTileUpdates", function () {
 
   it("conveys living players left", function () {
     const board = [
-      [" ", " ", "Pa<"],
+      [" ", " ", "Pa.<"],
     ];
     const state = new State(arrayToBoard(board));
 
     const intermediateBoards = [
       [
-        [" ", "Pa", " <"],
+        [" ", "Pa.", " <"],
       ],
     ];
 
@@ -1167,7 +1165,7 @@ describe("applyPatternTileUpdates", function () {
 
   it("left-conveyed die by crashing into players", function () {
     const board = [
-      [" ", "Pd", "Pa<"],
+      [" ", "Pd", "Pa.<"],
     ];
     const state = new State(arrayToBoard(board));
 
@@ -1182,7 +1180,7 @@ describe("applyPatternTileUpdates", function () {
 
   it("left-conveyed players kill living players", function () {
     const board = [
-      [" ", "Pa", "Pa<"],
+      [" ", "Pa.", "Pa.<"],
     ];
     const state = new State(arrayToBoard(board));
 
@@ -1197,13 +1195,13 @@ describe("applyPatternTileUpdates", function () {
 
   it("left-conveyed living players push single rocks", function () {
     const board = [
-      [" ", " ", "R.", "Pa<"],
+      [" ", " ", "R.", "Pa.<"],
     ];
     const state = new State(arrayToBoard(board));
 
     const intermediateBoards = [
       [
-        [" ", "R.", "Pa", " <"],
+        [" ", "R.", "Pa.", " <"],
       ],
     ];
 
@@ -1227,7 +1225,7 @@ describe("applyPatternTileUpdates", function () {
 
   it("left-conveyed players crash into double rocks rocks", function () {
     const board = [
-      [" ", "R.", "R.", "Pa<"],
+      [" ", "R.", "R.", "Pa.<"],
     ];
     const state = new State(arrayToBoard(board));
 
@@ -1242,7 +1240,7 @@ describe("applyPatternTileUpdates", function () {
 
   it("left-conveyed rocks kill players", function () {
     const board = [
-      [" ", "Pa", "R.", "Pa<"],
+      [" ", "Pa.", "R.", "Pa.<"],
     ];
     const state = new State(arrayToBoard(board));
 
@@ -1257,13 +1255,13 @@ describe("applyPatternTileUpdates", function () {
 
   it("conveys living players right", function () {
     const board = [
-      ["Pa>", " ", " "],
+      ["Pa.>", " ", " "],
     ];
     const state = new State(arrayToBoard(board));
 
     const intermediateBoards = [
       [
-        [" >", "Pa", " "],
+        [" >", "Pa.", " "],
       ],
     ];
 
@@ -1287,7 +1285,7 @@ describe("applyPatternTileUpdates", function () {
 
   it("right-conveyed die by crashing into players", function () {
     const board = [
-      ["Pa>", "Pd", " "],
+      ["Pa.>", "Pd", " "],
     ];
     const state = new State(arrayToBoard(board));
 
@@ -1302,7 +1300,7 @@ describe("applyPatternTileUpdates", function () {
 
   it("right-conveyed players kill living players", function () {
     const board = [
-      ["Pa>", "Pa", " "],
+      ["Pa.>", "Pa.", " "],
     ];
     const state = new State(arrayToBoard(board));
 
@@ -1317,13 +1315,13 @@ describe("applyPatternTileUpdates", function () {
 
   it("right-conveyed living players push single rocks", function () {
     const board = [
-      ["Pa>", "R.", " ", " "],
+      ["Pa.>", "R.", " ", " "],
     ];
     const state = new State(arrayToBoard(board));
 
     const intermediateBoards = [
       [
-        [" >", "Pa", "R.", " "],
+        [" >", "Pa.", "R.", " "],
       ],
     ];
 
@@ -1347,7 +1345,7 @@ describe("applyPatternTileUpdates", function () {
 
   it("right-conveyed players crash into double rocks rocks", function () {
     const board = [
-      ["Pa>", "R.", "R.", " "],
+      ["Pa.>", "R.", "R.", " "],
     ];
     const state = new State(arrayToBoard(board));
 
@@ -1362,7 +1360,7 @@ describe("applyPatternTileUpdates", function () {
 
   it("right-conveyed rocks kill players", function () {
     const board = [
-      ["Pa>", "R.", "Pa", " "],
+      ["Pa.>", "R.", "Pa.", " "],
     ];
     const state = new State(arrayToBoard(board));
 
@@ -1379,14 +1377,14 @@ describe("applyPatternTileUpdates", function () {
     const board = [
       [" "],
       [" "],
-      ["Pa^"],
+      ["Pa.^"],
     ];
     const state = new State(arrayToBoard(board));
 
     const intermediateBoards = [
       [
         [" "],
-        ["Pa"],
+        ["Pa."],
         [" ^"],
       ],
     ];
@@ -1417,7 +1415,7 @@ describe("applyPatternTileUpdates", function () {
     const board = [
       [" "],
       ["Pd"],
-      ["Pa^"],
+      ["Pa.^"],
     ];
     const state = new State(arrayToBoard(board));
 
@@ -1435,8 +1433,8 @@ describe("applyPatternTileUpdates", function () {
   it("up-conveyed players kill living players", function () {
     const board = [
       [" "],
-      ["Pa"],
-      ["Pa^"],
+      ["Pa."],
+      ["Pa.^"],
     ];
     const state = new State(arrayToBoard(board));
 
@@ -1456,7 +1454,7 @@ describe("applyPatternTileUpdates", function () {
       [" "],
       [" "],
       ["R."],
-      ["Pa^"],
+      ["Pa.^"],
     ];
     const state = new State(arrayToBoard(board));
 
@@ -1464,7 +1462,7 @@ describe("applyPatternTileUpdates", function () {
       [
         [" "],
         ["R."],
-        ["Pa"],
+        ["Pa."],
         [" ^"],
       ],
     ];
@@ -1498,7 +1496,7 @@ describe("applyPatternTileUpdates", function () {
       [" "],
       ["R."],
       ["R."],
-      ["Pa^"],
+      ["Pa.^"],
     ];
     const state = new State(arrayToBoard(board));
 
@@ -1517,9 +1515,9 @@ describe("applyPatternTileUpdates", function () {
   it("up-conveyed rocks kill players", function () {
     const board = [
       [" "],
-      ["Pa"],
+      ["Pa."],
       ["R."],
-      ["Pa^"],
+      ["Pa.^"],
     ];
     const state = new State(arrayToBoard(board));
 
@@ -1540,7 +1538,7 @@ describe("applyPatternTileUpdates", function () {
       ["R."],
       [" ^"],
       [" ^"],
-      ["Pa^"],
+      ["Pa.^"],
     ];
     const state = new State(arrayToBoard(board));
 
@@ -1548,7 +1546,7 @@ describe("applyPatternTileUpdates", function () {
       [
         [" "],
         ["Rv^"],
-        ["Pa^"],
+        ["Pa.^"],
         [" ^"],
       ],
       [
@@ -1556,6 +1554,183 @@ describe("applyPatternTileUpdates", function () {
         ["Pd^"],
         [" ^"],
         [" ^"],
+      ],
+    ];
+
+    stabilizeState(state, intermediateBoards);
+  });
+
+  it("down-moving players move into empty spaces", function () {
+    const board = [
+      ["Pav"],
+      [" "],
+    ];
+    const state = new State(arrayToBoard(board));
+
+    const intermediateBoards = [
+      [
+        [" "],
+        ["Pa."],
+      ],
+    ];
+
+    stabilizeState(state, intermediateBoards);
+  });
+
+  it("down-moving players are stopped by non-empty spaces", function () {
+    const board = [
+      ["Pav"],
+      ["W"],
+    ];
+    const state = new State(arrayToBoard(board));
+
+    const intermediateBoards = [
+      [
+        ["Pa."],
+        ["W"],
+      ],
+    ];
+
+    stabilizeState(state, intermediateBoards);
+  });
+
+  it("left-moving players move into empty spaces", function () {
+    const board = [
+      [" ", "Pa<"],
+    ];
+    const state = new State(arrayToBoard(board));
+
+    const intermediateBoards = [
+      [
+        ["Pa.", " "],
+      ],
+    ];
+
+    stabilizeState(state, intermediateBoards);
+  });
+
+  it("left-moving players are stopped by non-empty spaces", function () {
+    const board = [
+      ["W", "Pa<"],
+    ];
+    const state = new State(arrayToBoard(board));
+
+    const intermediateBoards = [
+      [
+        ["W", "Pa."],
+      ],
+    ];
+
+    stabilizeState(state, intermediateBoards);
+  });
+
+  it("left-moving players push single rocks", function () {
+    const board = [
+      [" ", "R.", "Pa<"],
+    ];
+    const state = new State(arrayToBoard(board));
+
+    const intermediateBoards = [
+      [
+        ["R.", "Pa.", " "],
+      ],
+    ];
+
+    stabilizeState(state, intermediateBoards);
+  });
+
+  it("right-moving players move into empty spaces", function () {
+    const board = [
+      ["Pa>", " "],
+    ];
+    const state = new State(arrayToBoard(board));
+
+    const intermediateBoards = [
+      [
+        [" ", "Pa."],
+      ],
+    ];
+
+    stabilizeState(state, intermediateBoards);
+  });
+
+  it("right-moving players are stopped by non-empty spaces", function () {
+    const board = [
+      ["Pa>", "W"],
+    ];
+    const state = new State(arrayToBoard(board));
+
+    const intermediateBoards = [
+      [
+        ["Pa.", "W"],
+      ],
+    ];
+
+    stabilizeState(state, intermediateBoards);
+  });
+
+  it("right-moving players push single rocks", function () {
+    const board = [
+      ["Pa>", "R.", " "],
+    ];
+    const state = new State(arrayToBoard(board));
+
+    const intermediateBoards = [
+      [
+        [" ", "Pa.", "R."],
+      ],
+    ];
+
+    stabilizeState(state, intermediateBoards);
+  });
+
+  it("up-moving players move into empty spaces", function () {
+    const board = [
+      [" "],
+      ["Pa^"],
+    ];
+    const state = new State(arrayToBoard(board));
+
+    const intermediateBoards = [
+      [
+        ["Pa."],
+        [" "],
+      ],
+    ];
+
+    stabilizeState(state, intermediateBoards);
+  });
+
+  it("up-moving players are stopped by non-empty spaces", function () {
+    const board = [
+      ["W"],
+      ["Pa^"],
+    ];
+    const state = new State(arrayToBoard(board));
+
+    const intermediateBoards = [
+      [
+        ["W"],
+        ["Pa."],
+      ],
+    ];
+
+    stabilizeState(state, intermediateBoards);
+  });
+
+  it("up-moving players push single rocks", function () {
+    const board = [
+      [" "],
+      ["R."],
+      ["Pa^"],
+    ];
+    const state = new State(arrayToBoard(board));
+
+    const intermediateBoards = [
+      [
+        ["R."],
+        ["Pa."],
+        [" "],
       ],
     ];
 

--- a/test/tile.spec.js
+++ b/test/tile.spec.js
@@ -77,10 +77,51 @@ const successCases = [
     {
       type: "Player",
       conveyorDirection: "None",
+      inputDirection: "Down",
       isAlive: true,
       justUpdated: false,
     },
-    "Pa",
+    "Pav",
+  ],
+  [
+    {
+      type: "Player",
+      conveyorDirection: "None",
+      inputDirection: "Left",
+      isAlive: true,
+      justUpdated: false,
+    },
+    "Pa<",
+  ],
+  [
+    {
+      type: "Player",
+      conveyorDirection: "None",
+      inputDirection: "None",
+      isAlive: true,
+      justUpdated: false,
+    },
+    "Pa.",
+  ],
+  [
+    {
+      type: "Player",
+      conveyorDirection: "None",
+      inputDirection: "Right",
+      isAlive: true,
+      justUpdated: false,
+    },
+    "Pa>",
+  ],
+  [
+    {
+      type: "Player",
+      conveyorDirection: "None",
+      inputDirection: "Up",
+      isAlive: true,
+      justUpdated: false,
+    },
+    "Pa^",
   ],
   [
     {
@@ -200,6 +241,7 @@ describe("decodeTile", function () {
     ["D#", "Unexpected flow direction # at 1"],
     ["P", "Unexpected player status undefined at 1"],
     ["Pz", "Unexpected player status z at 1"],
+    ["Paz", "Unexpected input direction z at 2"],
     ["R", "Unexpected falling direction undefined at 1"],
     ["Rz", "Unexpected falling direction z at 1"],
     ["~", "Unexpected flow direction undefined at 1"],


### PR DESCRIPTION
This fixes #13

Much of the player input logic was handled outside of the state machine and duplicated logic handled in other states. This change moves all of this logic into the state machine.

Living players now also have an input direction which causes them to move, if possible, in that direction. Once this state is handled the input direction automatically returns to no movement.

Moving player input handling into the state machine also makes it possible to allow players to move while the rest of the state machine is running since their input is handled on the same clock as the rest of the simulation.