### PR TITLE
Level creator doesn't create water source tiles

### DIFF
--- a/index.html
+++ b/index.html
@@ -247,8 +247,7 @@
         case "Water":
           return {
             type,
-            isSource: true,
-            flowDirection: "Both",
+            flowDirection: "All",
             justUpdated: false,
             conveyorDirection,
           };


### PR DESCRIPTION
Fixes #27

The level creator was creating a water tile with the improper flow direction. This change uses the proper direction and removes the unused `isSource` field.