### PR TITLE
Falling rocks kill and roll off players

### DIFF
--- a/src/patterns.js
+++ b/src/patterns.js
@@ -657,17 +657,17 @@ export const patterns = [
     ],
   ],
   [
-    "Rocks that fall down kill players and stop",
+    "Rocks fall left off of and kill a player",
     [
       [null],
-      [null, isFallingRock, null],
-      [null, null, isLivingPlayer, null, null],
+      [isEmptyForRock, isFallingRock, null],
+      [null, isEmptyForRock, isLivingPlayer, null, null],
       [null, null, null],
     ],
     [
       [null],
-      [null, rock("None"), null],
-      [null, null, deadPlayer],
+      [null, empty, null],
+      [null, rock("DownLeft"), deadPlayer],
     ],
   ],
   [
@@ -699,6 +699,20 @@ export const patterns = [
     ],
   ],
   [
+    "Rocks fall right off of and kill a player",
+    [
+      [null],
+      [isFallingRock, isEmptyForRock, null],
+      [null, isLivingPlayer, isEmptyForRock, null, null],
+      [null, null, null],
+    ],
+    [
+      [null],
+      [empty, null, null],
+      [null, deadPlayer, rock("DownRight")],
+    ],
+  ],
+  [
     "Rocks fall right off a hard surface",
     [
       [null],
@@ -723,6 +737,20 @@ export const patterns = [
     [
       [null],
       [rock("None"), null, null],
+      [null, null, deadPlayer],
+    ],
+  ],
+  [
+    "Rocks that fall down kill players and stop",
+    [
+      [null],
+      [null, isFallingRock, null],
+      [null, null, isLivingPlayer, null, null],
+      [null, null, null],
+    ],
+    [
+      [null],
+      [null, rock("None"), null],
       [null, null, deadPlayer],
     ],
   ],

--- a/test/state.spec.js
+++ b/test/state.spec.js
@@ -498,6 +498,61 @@ describe("applyPatternTileUpdates", function () {
     stabilizeState(state, intermediateBoards);
   });
 
+  it("ensures rocks falling down kill a player and roll left", function () {
+    const board = [
+      [" ", "R."],
+      [" ", " "],
+      [" ", "Pa."],
+    ];
+    const state = new State(arrayToBoard(board));
+
+    /** @type {TestBoard[]} */
+    const intermediateBoards = [
+      [
+        [" ", " "],
+        [" ", "Rv"],
+        [" ", "Pa."],
+      ],
+      [
+        [" ", " "],
+        [" ", " "],
+        ["R.", "Pd"],
+      ],
+    ];
+
+    stabilizeState(state, intermediateBoards);
+  });
+
+  it("ensures rocks falling down kill a player and roll right", function () {
+    const board = [
+      ["R.", " "],
+      [" ", " "],
+      ["Pa.", " "],
+    ];
+    const state = new State(arrayToBoard(board));
+
+    /** @type {TestBoard[]} */
+    const intermediateBoards = [
+      [
+        [" ", " "],
+        ["Rv", " "],
+        ["Pa.", " "],
+      ],
+      [
+        [" ", " "],
+        [" ", " "],
+        ["Pd", "R>"],
+      ],
+      [
+        [" ", " "],
+        [" ", " "],
+        ["Pd", "R."],
+      ],
+    ];
+
+    stabilizeState(state, intermediateBoards);
+  });
+
   it("ensures rocks falling down left kill a player", function () {
     const board = [
       [" ", "R."],


### PR DESCRIPTION
Fixes #33

The rule that caused falling rocks to be killed by falling rocks was too general of a rule for its location in the list of rules. General rules should come before more specific rules in order to allow the more specific rules to accurately run.

In this case, the location of this general rule caused me to not understand that specific rules were necessary to handle the case where a rock could fall and roll off a player. The rule that causes a rock to roll to the right actually ends up running before the rule killing the player because the empty tile to the right of the player is what pulls the rock into it.

The fix is to add new rules that specially handle rocks rolling off of living players and to move the more general rule after these more specific rules.